### PR TITLE
Switch params due to compilation error

### DIFF
--- a/src/main/java/it/pagopa/pn/client/b2b/pa/testclient/PnIoUserAttributerExternaClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/testclient/PnIoUserAttributerExternaClientImpl.java
@@ -48,7 +48,7 @@ public class PnIoUserAttributerExternaClientImpl implements IPnIoUserAttributerE
     }
 
     public void setCourtesyAddressIo(String xPagopaCxTaxid, IoCourtesyDigitalAddressActivation ioCourtesyDigitalAddressActivation) throws RestClientException {
-        courtesyApiIo.setCourtesyAddressIo(ioCourtesyDigitalAddressActivation, xPagopaCxTaxid);
+        courtesyApiIo.setCourtesyAddressIo(xPagopaCxTaxid, ioCourtesyDigitalAddressActivation);
     }
 
 }


### PR DESCRIPTION
Method `courtesyApiIo.setCourtesyAddressIo` accepts two parameters: first is a `String` and the second is a `IoCourtesyDigitalAddressActivation`.

This fix allow us to run the e2e tests; otherwise a compile error is thrown.