### PR TITLE
Review casi di test notifiche digitali - utilizzo pec Namirial

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/utils/NotificationValue.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/NotificationValue.java
@@ -36,7 +36,7 @@ public enum NotificationValue {
     INTERNAL_ID("internalId","",false),
     DIGITAL_DOMICILE("digitalDomicile","",false),
     DIGITAL_DOMICILE_TYPE("digitalDomicile_type","PEC",false),
-    DIGITAL_DOMICILE_ADDRESS("digitalDomicile_address","pectest@pec.pagopa.it",false),
+    DIGITAL_DOMICILE_ADDRESS("digitalDomicile_address","destinatario@certificatanoprod.notifichedigitali.it",false),
     PHYSICAL_ADDRES("physicalAddress","",false),
     PHYSICAL_ADDRESS_ADDRESS("physicalAddress_address","Via senza nome",false),
     PHYSICAL_ADDRESS_MUNICIPALITY("physicalAddress_municipality","Cosenza",false),

--- a/src/test/resources/it/pagopa/pn/cucumber/baseFunction/contentVerify/LegalFactContentVerify.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/baseFunction/contentVerify/LegalFactContentVerify.feature
@@ -17,7 +17,7 @@ Feature: Verifica del contenuto dei differenti tipi di legalFact prodotti nei wo
       | CF_MITTENTE                               | 80016350821                                                                                                |
       | DESTINATARIO_NOME_COGNOME_RAGIONE_SOCIALE | Mario Gherkin                                                                                              |
       | DESTINATARIO_CODICE_FISCALE               | CLMCST42R12D969Z                                                                                           |
-      | DESTINATARIO_DOMICILIO_DIGITALE           | pectest@pec.pagopa.it                                                                                      |
+      | DESTINATARIO_DOMICILIO_DIGITALE           | destinatario@certificatanoprod.notifichedigitali.it                                                                                      |
       | DESTINATARIO_TIPO_DOMICILIO_DIGITALE      | Domicilio eletto presso la Pubblica Amministrazione mittente ex art.26, comma 5 lettera b del D.L. 76/2020 |
       | DESTINATARIO_INDIRIZZO_FISICO             | Mario Gherkin Presso SCALA B VIA SENZA NOME 87100 COSENZA COSENZA CS ITALIA                                |
 
@@ -96,7 +96,7 @@ Feature: Verifica del contenuto dei differenti tipi di legalFact prodotti nei wo
       | TITLE                                     | Attestazione opponibile a terzi: notifica digitale                                                         |
       | DESTINATARIO_NOME_COGNOME_RAGIONE_SOCIALE | Mario Gherkin                                                                                              |
       | DESTINATARIO_CODICE_FISCALE               | CLMCST42R12D969Z                                                                                           |
-      | DESTINATARIO_DOMICILIO_DIGITALE           | pectest@pec.pagopa.it                                                                                      |
+      | DESTINATARIO_DOMICILIO_DIGITALE           | destinatario@certificatanoprod.notifichedigitali.it                                                                                      |
       | DESTINATARIO_TIPO_DOMICILIO_DIGITALE      | Domicilio eletto presso la Pubblica Amministrazione mittente ex art.26, comma 5 lettera b del D.L. 76/2020 |
 
   @legalFact

--- a/src/test/resources/it/pagopa/pn/cucumber/pagamentiMultipli/PagamentiMultiPG.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/pagamentiMultipli/PagamentiMultiPG.feature
@@ -1722,7 +1722,7 @@ Feature: avanzamento notifiche b2b persona giuridica multi pagamento
       | denomination         | Vita Nova Sas               |
       | recipientType        | PG                          |
       | taxId                | 12666810299                 |
-      | digitalDomicile_address | pectest@pec.pagopa.it    |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it    |
       | payment_pagoPaForm      | NULL                     |
       | payment_f24             | PAYMENT_F24_STANDARD     |
       | title_payment           | F24_STANDARD_12666810299 |
@@ -1764,7 +1764,7 @@ Feature: avanzamento notifiche b2b persona giuridica multi pagamento
       | denomination            | Vita Nova Sas            |
       | recipientType           | PG                       |
       | taxId                   | 12666810299              |
-      | digitalDomicile_address | pectest@pec.pagopa.it    |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it    |
       | payment_pagoPaForm      | NULL                     |
       | payment_f24             | PAYMENT_F24_STANDARD     |
       | title_payment           | F24_STANDARD_12666810299 |
@@ -1806,7 +1806,7 @@ Feature: avanzamento notifiche b2b persona giuridica multi pagamento
       | denomination            | Vita Nova Sas         |
       | recipientType           | PG                    |
       | taxId                   | 12666810299           |
-      | digitalDomicile_address | pectest@pec.pagopa.it |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it |
       | title_payment           | F24_FLAT_12666810299  |
       | payment_pagoPaForm      | NULL                  |
       | payment_f24             | PAYMENT_F24_FLAT      |
@@ -1848,7 +1848,7 @@ Feature: avanzamento notifiche b2b persona giuridica multi pagamento
       | denomination            | Vita Nova Sas         |
       | recipientType           | PG                    |
       | taxId                   | 12666810299           |
-      | digitalDomicile_address | pectest@pec.pagopa.it |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it |
       | title_payment           | F24_FLAT_12666810299  |
       | payment_pagoPaForm      | NULL                  |
       | payment_f24             | PAYMENT_F24_FLAT      |

--- a/src/test/resources/it/pagopa/pn/cucumber/pagamentiMultipli/PagamentiMultipli.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/pagamentiMultipli/PagamentiMultipli.feature
@@ -1498,7 +1498,7 @@ Feature: avanzamento notifiche b2b persona fisica multi pagamento
     And destinatario Mario Cucumber e:
       | payment_pagoPaForm      | NULL                  |
       | payment_f24             | PAYMENT_F24_STANDARD  |
-      | digitalDomicile_address | pectest@pec.pagopa.it |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it |
       | title_payment           | F24_STANDARD_MARIO    |
       | apply_cost_f24          | SI                    |
       | payment_multy_number    | 1                     |
@@ -2814,7 +2814,7 @@ Feature: avanzamento notifiche b2b persona fisica multi pagamento
       | feePolicy             | DELIVERY_MODE               |
       | paFee                 | 0                           |
     And destinatario Mario Gherkin e:
-      | digitalDomicile_address | pectest@pec.pagopa.it         |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it         |
       | payment_pagoPaForm      | NULL                          |
       | payment_f24             | PAYMENT_F24_STANDARD          |
       | title_payment           | F24_STANDARD_CLMCST42R12D969Z |
@@ -2852,7 +2852,7 @@ Feature: avanzamento notifiche b2b persona fisica multi pagamento
       | feePolicy             | DELIVERY_MODE               |
       | paFee                 | 100                         |
     And destinatario Mario Gherkin e:
-      | digitalDomicile_address | pectest@pec.pagopa.it         |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it         |
       | payment_pagoPaForm      | NULL                          |
       | payment_f24             | PAYMENT_F24_STANDARD          |
       | title_payment           | F24_STANDARD_CLMCST42R12D969Z |
@@ -2889,7 +2889,7 @@ Feature: avanzamento notifiche b2b persona fisica multi pagamento
       | paFee              | 0                           |
     And destinatario Mario Gherkin e:
       | title_payment           | F24_FLAT_CLMCST42R12D969Z |
-      | digitalDomicile_address | pectest@pec.pagopa.it     |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it     |
       | payment_pagoPaForm      | NULL                      |
       | payment_f24             | PAYMENT_F24_FLAT          |
       | apply_cost_pagopa       | NO                        |
@@ -2924,7 +2924,7 @@ Feature: avanzamento notifiche b2b persona fisica multi pagamento
       | feePolicy          | FLAT_RATE                   |
       | paFee              | 100                         |
     And destinatario Mario Gherkin e:
-      | digitalDomicile_address | pectest@pec.pagopa.it     |
+      | digitalDomicile_address | destinatario@certificatanoprod.notifichedigitali.it     |
       | title_payment           | F24_FLAT_CLMCST42R12D969Z |
       | payment_pagoPaForm      | NULL                      |
       | payment_f24             | PAYMENT_F24_FLAT          |

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/download/pf/AvanzamentoNotifichePFLegalFact.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/download/pf/AvanzamentoNotifichePFLegalFact.feature
@@ -36,7 +36,7 @@ Feature: Download legalFact
       | subject | invio notifica con cucumber |
       | senderDenomination | Comune di milano |
     And destinatario Mario Gherkin e:
-      |digitalDomicile_address|pectest@pec.pagopa.it|
+      |digitalDomicile_address|destinatario@certificatanoprod.notifichedigitali.it|
     When la notifica viene inviata tramite api b2b dal "Comune_1" e si attende che lo stato diventi ACCEPTED
     And vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_DIGITAL_PROGRESS"
     Then la PA richiede il download dell'attestazione opponibile PEC_RECEIPT
@@ -47,7 +47,7 @@ Feature: Download legalFact
       | subject | invio notifica con cucumber |
       | senderDenomination | Comune di milano |
     And destinatario Mario Gherkin e:
-      |digitalDomicile_address|pectest@pec.pagopa.it|
+      |digitalDomicile_address|destinatario@certificatanoprod.notifichedigitali.it|
     When la notifica viene inviata tramite api b2b dal "Comune_1" e si attende che lo stato diventi ACCEPTED
     And vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_DIGITAL_PROGRESS"
     Then "Mario Gherkin" richiede il download dell'attestazione opponibile PEC_RECEIPT


### PR DESCRIPTION
utilizzo pec Namirial in sostituzione di per Aruba