### PR TITLE
QA-4765: revisited agreement creation and reworked TC_INCARICATO_57

### DIFF
--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/DataPreparationService.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/DataPreparationService.java
@@ -64,6 +64,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -203,7 +204,7 @@ public class DataPreparationService {
 
     public UUID createAgreementWithGivenState(AgreementState agreementState, UUID eServiceID, UUID descriptorId, UUID delegationId, File doc) {
         // agreement in state DRAFT
-        UUID agreementId = createAgreement(eServiceID, descriptorId, delegationId);
+        UUID agreementId = createAndCheckAgreement(eServiceID, descriptorId, delegationId);
         if (doc != null) addConsumerDocumentToAgreement(agreementId, doc);
         return switch (agreementState) {
             case DRAFT -> agreementId;
@@ -226,14 +227,18 @@ public class DataPreparationService {
         };
     }
 
-    public UUID createAgreement(UUID eServiceID, UUID descriptorId) {
-        return createAgreement(eServiceID, descriptorId, null);
+    public UUID createAndCheckAgreement(UUID eServiceID, UUID descriptorId) {
+        return createAndCheckAgreement(eServiceID, descriptorId, null);
     }
 
-    public UUID createAgreement(UUID eServiceID, UUID descriptorId, UUID delegationId) {
+    public UUID createAgreement(UUID eServiceID, UUID descriptorId, @Nullable UUID delegationId) {
         httpCallExecutor.performCall(() -> agreementClient.createAgreement(sharedStepsContext.getXCorrelationId(), new AgreementPayload().eserviceId(eServiceID).descriptorId(descriptorId).delegationId(delegationId)));
+        return ((CreatedResource) httpCallExecutor.getResponse()).getId();
+    }
+
+    public UUID createAndCheckAgreement(UUID eServiceID, UUID descriptorId, UUID delegationId) {
+        UUID agreementId = createAgreement(eServiceID, descriptorId, delegationId);
         assertValidResponse();
-        UUID agreementId = ((CreatedResource) httpCallExecutor.getResponse()).getId();
         pollingService.makePolling(
             () ->  httpCallExecutor.performCall(() -> agreementClient.getAgreementById(sharedStepsContext.getXCorrelationId(), agreementId)),
             res -> res != HttpStatus.NOT_FOUND,
@@ -387,7 +392,7 @@ public class DataPreparationService {
 
         if (descriptorState == EServiceDescriptorState.DEPRECATED) {
             // Optional. Create an agreement
-            UUID agreementId = createAgreement(eServiceId, descriptorId);
+            UUID agreementId = createAndCheckAgreement(eServiceId, descriptorId);
             submitAgreement(agreementId, AgreementState.ACTIVE);
         }
 

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/DataPreparationService.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/DataPreparationService.java
@@ -60,6 +60,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -231,13 +232,18 @@ public class DataPreparationService {
         return createAndCheckAgreement(eServiceID, descriptorId, null);
     }
 
-    public UUID createAgreement(UUID eServiceID, UUID descriptorId, @Nullable UUID delegationId) {
-        httpCallExecutor.performCall(() -> agreementClient.createAgreement(sharedStepsContext.getXCorrelationId(), new AgreementPayload().eserviceId(eServiceID).descriptorId(descriptorId).delegationId(delegationId)));
-        return ((CreatedResource) httpCallExecutor.getResponse()).getId();
+    public Optional<UUID> createAgreement(UUID eServiceID, UUID descriptorId, @Nullable UUID delegationId) {
+        httpCallExecutor.performCall(() -> agreementClient.createAgreement(
+            sharedStepsContext.getXCorrelationId(),
+            new AgreementPayload().eserviceId(eServiceID).descriptorId(descriptorId).delegationId(delegationId)));
+        return httpCallExecutor.getClientResponse().is2xxSuccessful()
+            ? Optional.of(((CreatedResource) httpCallExecutor.getResponse()).getId())
+            : Optional.empty();
     }
 
     public UUID createAndCheckAgreement(UUID eServiceID, UUID descriptorId, UUID delegationId) {
-        UUID agreementId = createAgreement(eServiceID, descriptorId, delegationId);
+        UUID agreementId = createAgreement(eServiceID, descriptorId, delegationId).orElseThrow(
+            () -> new NoSuchElementException("Failed to create an agreement: result of agreement creation API is '%s'".formatted(httpCallExecutor.getClientResponse())));
         assertValidResponse();
         pollingService.makePolling(
             () ->  httpCallExecutor.performCall(() -> agreementClient.getAgreementById(sharedStepsContext.getXCorrelationId(), agreementId)),

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
@@ -37,9 +37,19 @@ public class AgreementCreationStep {
         tenantHasDeclinedThatRequest(tenantType);
     }
 
+    @Given("l'utente crea una richiesta di fruizione")
+    public void userCreatesRequestForService() {
+        clientTokenConfigurator.setBearerToken(sharedStepsContext.getUserToken());
+        UUID agreementId = dataPreparationService.createAgreement(
+            sharedStepsContext.getEServicesCommonContext().getEserviceId(),
+            sharedStepsContext.getEServicesCommonContext().getDescriptorId(),
+            null);
+        sharedStepsContext.setAgreementId(agreementId);
+    }
+
     @Given("{string} ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione")
     public void requestForServiceAlreadySubmittedAndPendingApproval(String tenantType) {
-        agreementProcessRequest(tenantType, null);
+        agreementProcessRequest(null);
     }
 
     @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione")
@@ -51,26 +61,24 @@ public class AgreementCreationStep {
     @Given("{string} ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione")
     public void delegationRequestForServiceAlreadySubmittedAndPendingApproval(String tenantType) {
         UUID delegationId = sharedStepsContext.getDelegationCommonContext().getDelegationId();
-        agreementProcessRequest(tenantType, delegationId);
+        agreementProcessRequest(delegationId);
     }
 
     @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione indicando una delega inesistente")
     public void delegationNotExistRequestForServiceAlreadySubmittedAndPendingApproval(DelegationRole delegationRole) {
-        String tenantType = sharedStepsContext.getDelegationCommonContext().getTenantBy(delegationRole);
         UUID delegationId = UUID.randomUUID();
-        agreementProcessRequest(tenantType, delegationId);
+        agreementProcessRequest(delegationId);
     }
 
     @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione indicando la delega dell'ente terzo")
     public void wrongDelegationRequestForServiceAlreadySubmittedAndPendingApproval(DelegationRole delegationRole) {
-        String tenantType = sharedStepsContext.getDelegationCommonContext().getTenantBy(delegationRole);
         UUID delegationId = sharedStepsContext.getDelegationCommonContext().getAuxDelegationId();
-        agreementProcessRequest(tenantType, delegationId);
+        agreementProcessRequest(delegationId);
     }
 
-    private void agreementProcessRequest(String tenantType, UUID delegationId) {
+    private void agreementProcessRequest(UUID delegationId) {
         clientTokenConfigurator.setBearerToken(sharedStepsContext.getUserToken());
-        UUID agreementId = dataPreparationService.createAgreement(
+        UUID agreementId = dataPreparationService.createAndCheckAgreement(
             sharedStepsContext.getEServicesCommonContext().getEserviceId(),
             sharedStepsContext.getEServicesCommonContext().getDescriptorId(),
             delegationId);

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
@@ -6,10 +6,13 @@ import it.pagopa.interop.generated.openapi.clients.bff.model.AgreementState;
 import it.pagopa.pn.interop.cucumber.steps.ClientTokenConfigurator;
 import it.pagopa.pn.interop.cucumber.steps.DataPreparationService;
 import it.pagopa.pn.interop.cucumber.steps.SharedStepsContext;
-
 import it.pagopa.pn.interop.cucumber.steps.delegate.DelegationRole;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AgreementCreationStep {
     private final ClientTokenConfigurator clientTokenConfigurator;
     private final IdentityService identityService;
@@ -44,11 +47,11 @@ public class AgreementCreationStep {
 
     private void agreementCreationRequest(UUID delegationId) {
         clientTokenConfigurator.setBearerToken(sharedStepsContext.getUserToken());
-        UUID agreementId = dataPreparationService.createAgreement(
+        Optional<UUID> agreementId = dataPreparationService.createAgreement(
             sharedStepsContext.getEServicesCommonContext().getEserviceId(),
             sharedStepsContext.getEServicesCommonContext().getDescriptorId(),
             delegationId);
-        sharedStepsContext.setAgreementId(agreementId);
+        sharedStepsContext.setAgreementId(agreementId.orElse(null));
     }
 
     @Given("{string} ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione")
@@ -75,7 +78,10 @@ public class AgreementCreationStep {
 
     @Given("l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo")
     public void wrongDelegationRequestForServiceAlreadySubmittedAndPendingApproval() {
-        UUID delegationId = sharedStepsContext.getDelegationCommonContext().getAuxDelegationId();
+        log.info("Actual delegation context: {}", sharedStepsContext.getDelegationCommonContext());
+        UUID delegationId = Objects.requireNonNull(
+            sharedStepsContext.getDelegationCommonContext().getAuxDelegationId(),
+            "Auxiliary delegation not found");
         agreementCreationRequest(delegationId);
     }
 

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/agreement/AgreementCreationStep.java
@@ -39,11 +39,15 @@ public class AgreementCreationStep {
 
     @Given("l'utente crea una richiesta di fruizione")
     public void userCreatesRequestForService() {
+        agreementCreationRequest(null);
+    }
+
+    private void agreementCreationRequest(UUID delegationId) {
         clientTokenConfigurator.setBearerToken(sharedStepsContext.getUserToken());
         UUID agreementId = dataPreparationService.createAgreement(
             sharedStepsContext.getEServicesCommonContext().getEserviceId(),
             sharedStepsContext.getEServicesCommonContext().getDescriptorId(),
-            null);
+            delegationId);
         sharedStepsContext.setAgreementId(agreementId);
     }
 
@@ -54,26 +58,25 @@ public class AgreementCreationStep {
 
     @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione")
     public void delegationRequestForServiceAlreadySubmittedAndPendingApproval(DelegationRole delegationRole) {
-        String tenantType = sharedStepsContext.getDelegationCommonContext().getTenantBy(delegationRole);
-        delegationRequestForServiceAlreadySubmittedAndPendingApproval(tenantType);
+        delegationRequestForServiceAlreadySubmittedAndPendingApproval();
     }
 
     @Given("{string} ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione")
-    public void delegationRequestForServiceAlreadySubmittedAndPendingApproval(String tenantType) {
+    public void delegationRequestForServiceAlreadySubmittedAndPendingApproval() {
         UUID delegationId = sharedStepsContext.getDelegationCommonContext().getDelegationId();
         agreementProcessRequest(delegationId);
     }
 
-    @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione indicando una delega inesistente")
-    public void delegationNotExistRequestForServiceAlreadySubmittedAndPendingApproval(DelegationRole delegationRole) {
+    @Given("l'utente ha già creato una richiesta di fruizione indicando una delega inesistente")
+    public void delegationNotExistRequestForServiceAlreadySubmittedAndPendingApproval() {
         UUID delegationId = UUID.randomUUID();
-        agreementProcessRequest(delegationId);
+        agreementCreationRequest(delegationId);
     }
 
-    @Given("il {delegationRole} ha già creato e inviato una richiesta di fruizione indicando la delega dell'ente terzo")
-    public void wrongDelegationRequestForServiceAlreadySubmittedAndPendingApproval(DelegationRole delegationRole) {
+    @Given("l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo")
+    public void wrongDelegationRequestForServiceAlreadySubmittedAndPendingApproval() {
         UUID delegationId = sharedStepsContext.getDelegationCommonContext().getAuxDelegationId();
-        agreementProcessRequest(delegationId);
+        agreementCreationRequest(delegationId);
     }
 
     private void agreementProcessRequest(UUID delegationId) {

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
@@ -89,6 +89,8 @@ Feature: Test API Availability in Use of E-Service
       | api,security|        403 |
       | support     |        403 |
 
+    # NOTA BUG: per il ruolo admin viene restituito 500, non il migliore degli stati d'errore. Esempio:
+    # Response Body: {"type":"about:blank","title":"Unexpected error","status":500,"detail":"Unexpected error","correlationId":"1e7c18d5-c2bf-4eb4-958b-26a12a051cc8","errors":[{"code":"9991","detail":"Unexpected error"}]}
     Scenario: [TC_INCARICATO_51] Richiamare l’API di accettazione di una delega in stato "revocata" deve produrre un errore
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
@@ -102,7 +104,10 @@ Feature: Test API Availability in Use of E-Service
     And l'ente delegato accetta la delega in fruizione
     Then si ottiene status code 403
 
-    Scenario Outline: [TC_INCARICATO_52] Richiamare l’API di accettazione di una delega in stato rifiutata
+    # NOTA BUG: per il ruolo admin viene restituito 500, non il migliore degli stati d'errore. Esempio:
+    # Response Body: {"type":"about:blank","title":"Unexpected error","status":500,"detail":"Unexpected error","correlationId":"1e7c18d5-c2bf-4eb4-958b-26a12a051cc8","errors":[{"code":"9991","detail":"Unexpected error"}]}
+    # TC_INCARICATO_56 invece ha un codice migliore, 409 [al momento di stesura del ticket non fare riferimento all'id del test ma a ciò che testa]
+  Scenario: [TC_INCARICATO_52] Richiamare l’API di accettazione di una delega in stato rifiutata
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
@@ -135,6 +140,8 @@ Feature: Test API Availability in Use of E-Service
       | api,security|        403 |
       | support     |        403 |
 
+    # NOTA BUG: per il ruolo admin viene restituito 500, non il migliore degli stati d'errore. Esempio:
+    # Response Body: {"type":"about:blank","title":"Unexpected error","status":500,"detail":"Unexpected error","correlationId":"1e7c18d5-c2bf-4eb4-958b-26a12a051cc8","errors":[{"code":"9991","detail":"Unexpected error"}]}
     Scenario: [TC_INCARICATO_54] Richiamare l’API di rifiuto su una delega in stato REVOKED
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
@@ -181,27 +188,32 @@ Feature: Test API Availability in Use of E-Service
     When l'ente delegato rifiuta la delega in fruizione
     Then si ottiene status code 409
 
-    Scenario Outline: [TC_INCARICATO_57] Richiamare l’API di creazione fruizione da parte di un delegato alla fruizione, specificando la delega corretta
-    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione con approvazione manuale
-    Given l'ente delegato "PA1"
-    And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-    And l'ente delegante "PA2"
-    And l'utente è un "admin" dell'ente delegante
-    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-    And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato accetta la delega in fruizione
-    And l'utente è un "<ruolo>" dell'ente delegato
-    When il delegato ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione
-    #When il delegato ha una richiesta di fruizione in stato "PENDING" per quell'e-service
-    Then si ottiene status code <statusCode>
+    Scenario: [TC_INCARICATO_57] Richiamare l’API di creazione fruizione da parte di un delegato alla fruizione, specificando la delega corretta
+      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione con approvazione manuale
+      Given l'ente delegato "PA1"
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+      And l'ente delegante "PA2"
+      And l'utente è un "admin" dell'ente delegante
+      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato accetta la delega in fruizione
+      And l'utente è un "admin" dell'ente delegato
+      When il delegato ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione
+      Then si ottiene status code 200
+
+  # Test non strettamente attinente la feature Incaricato, considerare di spostarlo altrove
+  Scenario Outline: [TC_INTEROP_NON-ADMIN_FRUITION_REQUEST] Un utente con ruolo NON amministratore NON può richiedere la fruizione di un e-service
+    Given "GSP" ha già creato e pubblicato 1 e-service
+    And l'utente è un "<ruolo>" di "PA1"
+    When l'utente crea una richiesta di fruizione
+    Then si ottiene status code 403
     Examples:
-      | ruolo       | statusCode |
-      | admin       |        200 |
-      | api         |        403 |
-      | security    |        403 |
-      | api,security|        403 |
-      | support     |        403 |
+      | ruolo        |
+      | api          |
+      | security     |
+      | api,security |
+      | support      |
 
 
     Scenario Outline: [TC_INCARICATO_58] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega inesistente

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
@@ -215,8 +215,21 @@ Feature: Test API Availability in Use of E-Service
       | api,security |
       | support      |
 
+    Scenario: [TC_INCARICATO_58] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega inesistente
+      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
+      Given l'ente delegato "PA1"
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+      And l'ente delegante "PA2"
+      And l'utente è un "admin" dell'ente delegante
+      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato accetta la delega in fruizione
+      And l'utente è un "admin" dell'ente delegato
+      When l'utente ha già creato una richiesta di fruizione indicando una delega inesistente
+      Then si ottiene status code 400
 
-    Scenario Outline: [TC_INCARICATO_58] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega inesistente
+    Scenario: [TC_INCARICATO_58_BIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete al delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
@@ -226,28 +239,7 @@ Feature: Test API Availability in Use of E-Service
     And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
     And l'utente è un "admin" dell'ente delegato
     And l'ente delegato accetta la delega in fruizione
-    And l'utente è un "<ruolo>" dell'ente delegato
-    When il delegato ha già creato e inviato una richiesta di fruizione indicando una delega inesistente
-    Then si ottiene status code <statusCode>
-    Examples:
-      | ruolo       | statusCode |
-      | admin       |        400 |
-      | api         |        403 |
-      | security    |        403 |
-      | api,security|        403 |
-      | support     |        403 |
-
-    Scenario Outline: [TC_INCARICATO_58_BIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete al delegato
-    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
-    Given l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-    And l'ente delegante "PA2"
-    And l'utente è un "admin" dell'ente delegante
-    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-    And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato accetta la delega in fruizione
-    And l'utente è un "<ruolo>" dell'ente delegato
 
     # Processo di produzione di una delega tra il delegante e un terzo ente
     And l'utente è un "admin" di "GSP2"
@@ -255,43 +247,30 @@ Feature: Test API Availability in Use of E-Service
     And l'utente è un "admin" dell'ente delegante
     And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
 
-    When il delegato ha già creato e inviato una richiesta di fruizione indicando la delega dell'ente terzo
-    Then si ottiene status code <statusCode>
-    Examples:
-      | ruolo       | statusCode |
-      | admin       |        400 |
-      | api         |        403 |
-      | security    |        403 |
-      | api,security|        403 |
-      | support     |        403 |
+    When l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo
+    Then si ottiene status code 400
 
-    Scenario Outline: [TC_INCARICATO_58_TRIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete né al delegante né al delegato
-    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
-    Given l'ente delegato "PA1"
-    And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-    And l'ente delegante "PA2"
-    And l'utente è un "admin" dell'ente delegante
-    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-    And l'utente è un "admin" dell'ente delegato
-    And l'ente delegato accetta la delega in fruizione
-    And l'utente è un "<ruolo>" dell'ente delegato
 
-    # Processo di produzione di una delega tra due enti diversi da delegante e delegato
-    And l'utente è un "admin" di "GSP2"
-    And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
-    And l'utente è un "admin" di "Privato"
-    And l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+    Scenario: [TC_INCARICATO_58_TRIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete né al delegante né al delegato
+      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
+      Given l'ente delegato "PA1"
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+      And l'ente delegante "PA2"
+      And l'utente è un "admin" dell'ente delegante
+      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+      And l'utente è un "admin" dell'ente delegato
+      And l'ente delegato accetta la delega in fruizione
+      And l'utente è un "admin" dell'ente delegato
 
-    When il delegato ha già creato e inviato una richiesta di fruizione indicando la delega dell'ente terzo
-    Then si ottiene status code <statusCode>
-    Examples:
-      | ruolo       | statusCode |
-      | admin       |        400 |
-      | api         |        403 |
-      | security    |        403 |
-      | api,security|        403 |
-      | support     |        403 |
+      # Processo di produzione di una delega tra due enti diversi da delegante e delegato
+      And l'utente è un "admin" di "GSP2"
+      And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
+      And l'utente è un "admin" di "Privato"
+      And l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+
+      When l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo
+      Then si ottiene status code 400
 
     Scenario Outline: [TC_INCARICATO_59] Richiamare l’API di accettazione di una richiesta di fruizione fatta da un delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
@@ -14,6 +14,7 @@ Feature: Test API Availability in Use of E-Service
     # TODO 07/02/2025: considerare di generalizzare così da resettare TUTTI gli enti automaticamente
     Given l'ente "PA2" rimuove la disponibilità a ricevere deleghe in fruizione
     And l'ente "PA1" rimuove la disponibilità a ricevere deleghe in fruizione
+    And l'ente "GSP2" rimuove la disponibilità a ricevere deleghe in fruizione
 
   Scenario Outline: [TC_INCARICATO_45] Verificare che il richiamo dell’API di disponibilità in fruizione di un e-service possa essere compiuto da un utente di tipo amministratore
     Given l'utente è un "<ruolo>" di "PA1"
@@ -188,19 +189,19 @@ Feature: Test API Availability in Use of E-Service
     When l'ente delegato rifiuta la delega in fruizione
     Then si ottiene status code 409
 
-    Scenario: [TC_INCARICATO_57] Richiamare l’API di creazione fruizione da parte di un delegato alla fruizione, specificando la delega corretta
-      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione con approvazione manuale
-      Given l'ente delegato "PA1"
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-      And l'ente delegante "PA2"
-      And l'utente è un "admin" dell'ente delegante
-      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato accetta la delega in fruizione
-      And l'utente è un "admin" dell'ente delegato
-      When il delegato ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione
-      Then si ottiene status code 200
+  Scenario: [TC_INCARICATO_57] Richiamare l’API di creazione fruizione da parte di un delegato alla fruizione, specificando la delega corretta
+    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione con approvazione manuale
+    Given l'ente delegato "PA1"
+    And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+    And l'ente delegante "PA2"
+    And l'utente è un "admin" dell'ente delegante
+    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+    And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato accetta la delega in fruizione
+    And l'utente è un "admin" dell'ente delegato
+    When il delegato ha già creato e inviato una richiesta di fruizione in delega ed è in attesa di approvazione
+    Then si ottiene status code 200
 
   # Test non strettamente attinente la feature Incaricato, considerare di spostarlo altrove
   Scenario Outline: [TC_INTEROP_NON-ADMIN_FRUITION_REQUEST] Un utente con ruolo NON amministratore NON può richiedere la fruizione di un e-service
@@ -215,23 +216,11 @@ Feature: Test API Availability in Use of E-Service
       | api,security |
       | support      |
 
-    Scenario: [TC_INCARICATO_58] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega inesistente
-      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
-      Given l'ente delegato "PA1"
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-      And l'ente delegante "PA2"
-      And l'utente è un "admin" dell'ente delegante
-      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato accetta la delega in fruizione
-      And l'utente è un "admin" dell'ente delegato
-      When l'utente ha già creato una richiesta di fruizione indicando una delega inesistente
-      Then si ottiene status code 400
-
-    Scenario: [TC_INCARICATO_58_BIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete al delegato
+  # NOTA BUG: per un risultato di tipo 'not found' ci si aspetterebbe un 404, non 400
+  # Response Body: {"type":"about:blank","title":"Delegation not found","status":400,"detail":"Delegation c3bb23e4-5b43-4cf9-88aa-704a5ebd0374 not found","correlationId":"30b9e0d1-372a-4105-af1e-8ae850b40d6a","errors":[{"code":"0026","detail":"Delegation c3bb23e4-5b43-4cf9-88aa-704a5ebd0374 not found"}]}
+  Scenario: [TC_INCARICATO_58] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega inesistente
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
-    Given l'ente delegato "PA1"
+    And l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
     And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
     And l'ente delegante "PA2"
@@ -239,40 +228,56 @@ Feature: Test API Availability in Use of E-Service
     And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
     And l'utente è un "admin" dell'ente delegato
     And l'ente delegato accetta la delega in fruizione
+    When l'utente ha già creato una richiesta di fruizione indicando una delega inesistente
+    Then si ottiene status code 404
+
+  Scenario: [TC_INCARICATO_58_BIS] L'ente delegante NON può creare una richiesta di fruizione per un e-service per il quale ha già creato una richiesta di fruizione
+    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
+    And l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+    And l'ente delegante "PA2"
+    And l'utente è un "admin" dell'ente delegante
+    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+    And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato accetta la delega in fruizione
 
     # Processo di produzione di una delega tra il delegante e un terzo ente
     And l'utente è un "admin" di "GSP2"
     And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
     And l'utente è un "admin" dell'ente delegante
-    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+    When l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+    Then si ottiene status code 409
+
+
+  # FIXME 10/02/2025: questo test non può essere fatto usando l'ente "Privato", per cui al passo
+  # -> l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+  # si ottiene la response
+  # -> {"type":"about:blank","title":"Origin is not compliant","status":403,"detail":"Delegator a7a87b2c-5742-43fb-a847-6304bb0414b4 with external origin IVASS is not allowed","correlationId":"81b68165-382c-4ee6-bba0-8bc64162c700","errors":[{"code":"0006","detail":"Delegator a7a87b2c-5742-43fb-a847-6304bb0414b4 with external origin IVASS is not allowed"}]}
+  # Ci sarebbe dunque bisogno di un nuovo ente che possa fare deleghe in fruizione a GSP2
+  @ignore
+  Scenario: [TC_INCARICATO_58_TRIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete né al delegante né al delegato
+    Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
+    And l'ente delegato "PA1"
+    And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
+    And l'ente delegante "PA2"
+    And l'utente è un "admin" dell'ente delegante
+    And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
+    And l'utente è un "admin" dell'ente delegato
+    And l'ente delegato accetta la delega in fruizione
+
+    # Processo di produzione di una delega tra due enti diversi da delegante e delegato
+    And l'utente è un "admin" di "GSP2"
+    And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
+    And l'utente è un "admin" di "Privato"
+    And l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+    And l'utente è un "admin" dell'ente delegato
 
     When l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo
-    Then si ottiene status code 400
+    Then si ottiene status code 403
 
-
-    Scenario: [TC_INCARICATO_58_TRIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete né al delegante né al delegato
-      Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
-      Given l'ente delegato "PA1"
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato concede la disponibilità a ricevere deleghe in fruizione
-      And l'ente delegante "PA2"
-      And l'utente è un "admin" dell'ente delegante
-      And l'ente delegante ha inoltrato una richiesta di delega in fruizione all'ente delegato
-      And l'utente è un "admin" dell'ente delegato
-      And l'ente delegato accetta la delega in fruizione
-      And l'utente è un "admin" dell'ente delegato
-
-      # Processo di produzione di una delega tra due enti diversi da delegante e delegato
-      And l'utente è un "admin" di "GSP2"
-      And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
-      And l'utente è un "admin" di "Privato"
-      And l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
-
-      When l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo
-      Then si ottiene status code 400
-
-    Scenario Outline: [TC_INCARICATO_59] Richiamare l’API di accettazione di una richiesta di fruizione fatta da un delegato
+  Scenario Outline: [TC_INCARICATO_59] Richiamare l’API di accettazione di una richiesta di fruizione fatta da un delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato
@@ -297,7 +302,7 @@ Feature: Test API Availability in Use of E-Service
       | support     |        403 |
 
 
-    Scenario Outline: [TC_INCARICATO_60] Richiamare l’API di rifiuto di una richiesta di fruizione fatta da un delegato
+  Scenario Outline: [TC_INCARICATO_60] Richiamare l’API di rifiuto di una richiesta di fruizione fatta da un delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     Given l'ente delegato "PA1"
     And l'utente è un "admin" dell'ente delegato

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/incaricato/consumer.feature
@@ -250,12 +250,8 @@ Feature: Test API Availability in Use of E-Service
     Then si ottiene status code 409
 
 
-  # FIXME 10/02/2025: questo test non può essere fatto usando l'ente "Privato", per cui al passo
-  # -> l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
-  # si ottiene la response
-  # -> {"type":"about:blank","title":"Origin is not compliant","status":403,"detail":"Delegator a7a87b2c-5742-43fb-a847-6304bb0414b4 with external origin IVASS is not allowed","correlationId":"81b68165-382c-4ee6-bba0-8bc64162c700","errors":[{"code":"0006","detail":"Delegator a7a87b2c-5742-43fb-a847-6304bb0414b4 with external origin IVASS is not allowed"}]}
-  # Ci sarebbe dunque bisogno di un nuovo ente che possa fare deleghe in fruizione a GSP2
-  @ignore
+  # NOTA BUG: per un risultato di tipo 'not found' ci si aspetterebbe un 404, non 400
+  # Response body: {"type":"about:blank","title":"Delegation not found","status":400,"detail":"Delegation dd54ea4f-3922-4ab5-847c-35765fef8efe not found","correlationId":"b1303079-d942-4f0b-ab71-765d389645c7","errors":[{"code":"0026","detail":"Delegation dd54ea4f-3922-4ab5-847c-35765fef8efe not found"}]}
   Scenario: [TC_INCARICATO_58_TRIS] Richiamare l’API di creazione di una richiesta di fruizione, specificando una delega che non compete né al delegante né al delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     And l'ente delegato "PA1"
@@ -270,12 +266,12 @@ Feature: Test API Availability in Use of E-Service
     # Processo di produzione di una delega tra due enti diversi da delegante e delegato
     And l'utente è un "admin" di "GSP2"
     And l'ente "GSP2" concede la disponibilità a ricevere deleghe in fruizione
-    And l'utente è un "admin" di "Privato"
-    And l'ente "Privato" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
+    And l'utente è un "admin" di "GSP"
+    And l'ente "GSP" ha inoltrato una richiesta di delega in fruizione all'ente terzo "GSP2"
     And l'utente è un "admin" dell'ente delegato
 
     When l'utente ha già creato una richiesta di fruizione indicando la delega dell'ente terzo
-    Then si ottiene status code 403
+    Then si ottiene status code 404
 
   Scenario Outline: [TC_INCARICATO_59] Richiamare l’API di accettazione di una richiesta di fruizione fatta da un delegato
     Given "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione con approvazione manuale
@@ -430,7 +426,7 @@ Feature: Test API Availability in Use of E-Service
     When l'utente richiede l'associazione della finalità al client
     Then si ottiene status code 403
 
-    Scenario Outline: [TC_INCARICATO_66] Il delegato richiama l’API di associazione di un client NON precedentemente creato
+    Scenario: [TC_INCARICATO_66] Il delegato richiama l’API di associazione di un client NON precedentemente creato
     Given l'utente è un "admin" di "GSP"
     And "GSP" ha già creato e pubblicato 1 e-service delegabile in fruizione
     And l'ente delegato "PA1"


### PR DESCRIPTION
**Contesto**
Il test TC_INCARICATO_57 funzionava solo per lo scenario con esito 200 ma non per gli altri, perché il codice che veniva richiamato includeva un check di buona riuscita della creazione della richiesta di fruizione, adatto per il caso 200 ma non per tutti gli altri (le cui chiamate devono fallire by design provocando un errore 403).

**Soluzione**
- Il test TC_INCARICATO_57 è stato ridotto al solo caso 200
- Il test dei casi fallimento per chiamante non autorizzato sono stati raccolti nel test TC_INTEROP_NON-ADMIN_FRUITION_REQUEST . 
La considerazione alla base di questo rework è che una richiesta di fruizione non autorizzata dovrebbe in realtà fallire a prescindere da qualunque meccanismo di delega, sia essa relativa all'SRS Incaricato o SRS Capofila; da qui l'idea di concentrare questo controllo in un test dedicato, molto più semplice e privo di qualsiasi logica di delega.