### PR TITLE
QA8120 - Aggiunta parametro Limite Massimo Stream Specifico per singola PA

### DIFF
--- a/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPGDigitaleNR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPGDigitaleNR.feature
@@ -54,14 +54,14 @@ Feature: avanzamento b2b notifica  digitale PG con chiamata a National Registry 
     When la notifica viene inviata tramite api b2b dal "Comune_1" e si attende che lo stato diventi "ACCEPTED"
     Then viene verificato che nell'elemento di timeline della notifica "PUBLIC_REGISTRY_RESPONSE" sia presente il campo Digital Address da National Registry
     And viene verificato che l'elemento di timeline "SEND_DIGITAL_FEEDBACK" esista
-      | loadTimeline                 | true                                                    |
-      | details                      | NOT_NULL                                                |
-      | details_responseStatus       | OK                                                      |
-      | details_sendingReceipts      | [{"id": null, "system": null}]                          |
-      | details_digitalAddress       | {"address": "example2@OK-pecSuccess.it", "type": "PEC"} |
-      | details_recIndex             | 0                                                       |
-      | details_digitalAddressSource | GENERAL                                                 |
-      | details_sentAttemptMade      | 0                                                       |
+      | loadTimeline                 | true                                             |
+      | details                      | NOT_NULL                                         |
+      | details_responseStatus       | OK                                               |
+      | details_sendingReceipts      | [{"id": null, "system": null}]                   |
+      | details_digitalAddress       | {"address": "00883601007@pec.it", "type": "PEC"} |
+      | details_recIndex             | 0                                                |
+      | details_digitalAddressSource | GENERAL                                          |
+      | details_sentAttemptMade      | 0                                                |
     And vengono letti gli eventi fino all'elemento di timeline della notifica "DIGITAL_SUCCESS_WORKFLOW"
 
   @dev @workflowDigitale @testLite @mockNR #da rimuovere una volta che abbiamo liberi professionisti con feature flag a true

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v23/WebhookV23Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v23/WebhookV23Creation.feature
@@ -21,7 +21,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV23 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V23"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V23"
@@ -50,7 +50,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV23 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V23"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V23"
@@ -79,7 +79,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV23 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V23"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V23"
@@ -107,7 +107,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV23 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V23"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V23"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v24/WebhookV24Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v24/WebhookV24Creation.feature
@@ -21,7 +21,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV24 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V24"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V24"
@@ -50,7 +50,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV24 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V24"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V24"
@@ -79,7 +79,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV24 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V24"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V24"
@@ -107,7 +107,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV24 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V24"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V24"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v25/WebhookV25Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v25/WebhookV25Creation.feature
@@ -21,7 +21,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV25 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V25"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V25"
@@ -50,7 +50,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV25 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V25"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V25"
@@ -79,7 +79,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV25 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V25"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V25"
@@ -107,7 +107,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV25 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V25"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V25"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v26/WebhookV26Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v26/WebhookV26Creation.feature
@@ -21,7 +21,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV26 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V26"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V26"
@@ -50,7 +50,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV26 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V26"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V26"
@@ -79,7 +79,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV26 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V26"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V26"
@@ -107,7 +107,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV26 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V26"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V26"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Creation.feature
@@ -20,7 +20,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
     And l'apiKey viene cancellata
 
-    # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_1waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
@@ -37,7 +37,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV27 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V27"
@@ -65,7 +65,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_3waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
@@ -82,7 +82,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV27 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V27"
@@ -110,7 +110,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_5waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
@@ -127,7 +127,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV27 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V27"
@@ -154,7 +154,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_7waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
@@ -170,7 +170,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV27 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V27"
@@ -196,7 +196,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_9waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"
@@ -245,7 +245,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_13waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"
@@ -295,7 +295,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_18waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "TIMELINE"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "TIMELINE" con versione "V27"
@@ -323,7 +323,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_19waitForAccepted] Creazione di uno stream notifica senza gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"
@@ -362,7 +362,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_22waitForAccepted] Creazione di uno stream notifica senza gruppo, con eventType "TIMELINE"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "TIMELINE" con versione "V27"
@@ -400,7 +400,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_25waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"
@@ -427,7 +427,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_148waitForAccepted] Creazione di uno stream notifica con gruppi appartenenti ad un sottinsieme dei gruppi dell'apikey utilizzata.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Update.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Update.feature
@@ -70,7 +70,7 @@ Feature: aggiornamento stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_89waitForAccepted] Aggiornamento di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"
@@ -112,7 +112,7 @@ Feature: aggiornamento stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV27 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_43waitForAccepted] Aggiornamento di uno stream notifica da un gruppo a più gruppi, con eventType "STATUS".
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V27"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v28/WebhookV28Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v28/WebhookV28Creation.feature
@@ -20,7 +20,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
     And l'apiKey viene cancellata
 
-    # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_1waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
@@ -37,7 +37,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV28 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V28"
@@ -47,6 +47,36 @@ Feature: verifica creazione stream
     And si creano i nuovi stream per il "Comune_Multi" con versione "V28"
     When si predispone 1 nuovo stream denominato "stream-test-11" con eventType "TIMELINE" con versione "V28"
     And si crea il nuovo stream per il "Comune_Multi" con versione "V28"
+    Then l'operazione ha prodotto un errore con status code "409"
+    And viene modificato lo stato dell'apiKey in "BLOCK"
+    And l'apiKey viene cancellata
+
+  @webhookV28 @precondition @cleanWebhook @webhook2
+  #LIMITE SPECIFICO PER PA: pnConfiguration.maxStreamsNumber = 9; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
+  Scenario: [B2B_STREAM_ES1_1_2_LIMITE_SPECIFICO_INFERIORE_DEFAULT] Creazione per una PA (avente un proprio limite massimo di stream pari a 9) di 10 nuovi stream notifica con eventType TIMELINE e senza gruppo.
+    Given vengono cancellati tutti gli stream presenti del "Comune_2" con versione "V28"
+    And si predispongono 9 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V28"
+    And Viene creata una nuova apiKey per il comune "Comune_2" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    And si creano i nuovi stream per il "Comune_2" con versione "V28"
+    When si predispone 1 nuovo stream denominato "stream-test-10" con eventType "TIMELINE" con versione "V28"
+    And si crea il nuovo stream per il "Comune_2" con versione "V28"
+    Then l'operazione ha prodotto un errore con status code "409"
+    And viene modificato lo stato dell'apiKey in "BLOCK"
+    And l'apiKey viene cancellata
+
+  @webhookV28 @precondition @cleanWebhook @webhook2
+  #LIMITE SPECIFICO PER PA: pnConfiguration.maxStreamsNumber = 11; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
+  Scenario: [B2B_STREAM_ES1_1_2_LIMITE_SPECIFICO_SUPERIORE_DEFAULT] Creazione per una PA (avente un proprio limite massimo di stream pari a 11) di 12 nuovi stream notifica con eventType TIMELINE e senza gruppo.
+    Given vengono cancellati tutti gli stream presenti del "Comune_1" con versione "V28"
+    And si predispongono 11 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V28"
+    And Viene creata una nuova apiKey per il comune "Comune_1" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    And si creano i nuovi stream per il "Comune_1" con versione "V28"
+    When si predispone 1 nuovo stream denominato "stream-test-12" con eventType "TIMELINE" con versione "V28"
+    And si crea il nuovo stream per il "Comune_1" con versione "V28"
     Then l'operazione ha prodotto un errore con status code "409"
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
@@ -65,7 +95,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_3waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
@@ -82,7 +112,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV28 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_4] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V28"
@@ -110,7 +140,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_5waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
@@ -127,7 +157,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV28 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_6] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS e senza gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V28"
@@ -154,7 +184,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_7waitForAccepted] Creazione per una PA di 10 nuovi stream notifica con eventType TIMELINE con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
@@ -170,7 +200,7 @@ Feature: verifica creazione stream
     And l'apiKey viene cancellata
 
   @webhookV28 @precondition @cleanWebhook @webhook2
-  #TODO: valutare se modificare, mettere in ignore, o riportare il limite di stream per una PA a 10 (attualmente è 100 e non genera alcun errore)
+  #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_8] Creazione per una PA di 11 nuovi stream notifica con eventType STATUS con gruppo.
     Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V28"
     And si predispongono 10 nuovi stream denominati "stream-test" con eventType "STATUS" con versione "V28"
@@ -196,7 +226,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_9waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"
@@ -245,7 +275,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_13waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"
@@ -295,7 +325,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_18waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "TIMELINE"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "TIMELINE" con versione "V28"
@@ -323,7 +353,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_19waitForAccepted] Creazione di uno stream notifica senza gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"
@@ -362,7 +392,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_22waitForAccepted] Creazione di uno stream notifica senza gruppo, con eventType "TIMELINE"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "TIMELINE" con versione "V28"
@@ -400,7 +430,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_25waitForAccepted] Creazione di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey master.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"
@@ -427,7 +457,7 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_148waitForAccepted] Creazione di uno stream notifica con gruppi appartenenti ad un sottinsieme dei gruppi dell'apikey utilizzata.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v28/WebhookV28Update.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v28/WebhookV28Update.feature
@@ -70,7 +70,7 @@ Feature: aggiornamento stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_89waitForAccepted] Aggiornamento di uno stream notifica con gruppo, con eventType "STATUS"  utilizzando un apikey con stesso gruppo.
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"
@@ -112,7 +112,7 @@ Feature: aggiornamento stream
     And viene modificato lo stato dell'apiKey in "BLOCK"
     And l'apiKey viene cancellata
 
-        # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
+  # identico al test sopra, ma stavolta waitForAccepted viene impostato a true
   @webhookV28 @precondition @cleanWebhook @webhook2
   Scenario: [B2B-STREAM_ES1.1_43waitForAccepted] Aggiornamento di uno stream notifica da un gruppo a più gruppi, con eventType "STATUS".
     Given si predispone 1 nuovo stream denominato "stream-test" con eventType "STATUS" con versione "V28"


### PR DESCRIPTION
Implementazione 2 nuovi test per limiti di creazione stream specifici per PA... TEST ID:
B2B_STREAM_ES1_1_2_LIMITE_SPECIFICO_INFERIORE_DEFAULT B2B_STREAM_ES1_1_2_LIMITE_SPECIFICO_SUPERIORE_DEFAULT
+ Fix per B2B_TIMELINE_7915_1
+ rimozione commenti su vecchi test (non falliscono più in seguito ad aggiornamento MaxStream su pnConfig)