### PR TITLE
Hotfix/fix SercQ, webhook v10 e un po' di migliorie

### DIFF
--- a/src/main/java/it/pagopa/pn/client/b2b/pa/polling/impl/v20/PnPollingServiceWebhookV20.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/polling/impl/v20/PnPollingServiceWebhookV20.java
@@ -170,6 +170,7 @@ public class PnPollingServiceWebhookV20 extends PnPollingTemplate<PnPollingRespo
 //                        && progressResponseElement.getTimelineEventCategory().equals(
 //                        pnPollingParameter.getPnPollingWebhook().getTimelineElementCategoryV23())
                         //TODO: con questo ci mettiamo una toppa, ma non è del tutto corretto
+                        && pnPollingParameter.getPnPollingWebhook().getTimelineElementCategoryV20() != null
                         && progressResponseElement.getTimelineEventCategory().getValue().equals(
                         pnPollingParameter.getPnPollingWebhook().getTimelineElementCategoryV20().getValue())
                         //TODO: questo è come dovrebbe essere (una volta sistemato il pom, scommentare e rimuovere quelli sopra)

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
@@ -27,7 +27,7 @@ public interface IPnWebUserAttributesClient extends SettableBearerToken {
 
     List<LegalCourtesyAddressWrapper> getLegalAddressByRecipient() throws RestClientException;
 
-    void postRecipientLegalAddress(String senderId, LegalChannelType channelType, AddressVerification addressVerification) throws RestClientException;
+    void postRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException;
 
     void deleteRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType) throws RestClientException;
 

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.client.b2b.pa.service;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableBearerToken;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyDigitalAddress;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.Consent;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.ConsentAction;
@@ -29,7 +30,7 @@ public interface IPnWebUserAttributesClient extends SettableBearerToken {
 
     void deleteRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException;
 
-    List<LegalCourtesyAddressWrapper> getCourtesyAddressByRecipient() throws RestClientException;
+    List<CourtesyDigitalAddress> getCourtesyAddressByRecipient() throws RestClientException;
 
     void postRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException;
 }

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/IPnWebUserAttributesClient.java
@@ -3,8 +3,6 @@ package it.pagopa.pn.client.b2b.pa.service;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableBearerToken;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyChannelType;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalChannelType;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.Consent;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.ConsentAction;
@@ -23,15 +21,15 @@ public interface IPnWebUserAttributesClient extends SettableBearerToken {
 
     UserAddresses getAddressesByRecipient() throws RestClientException;
 
-    void deleteRecipientLegalAddress(String senderId, LegalChannelType channelType) throws RestClientException;
+    void deleteRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException;
 
     List<LegalCourtesyAddressWrapper> getLegalAddressByRecipient() throws RestClientException;
 
     void postRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException;
 
-    void deleteRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType) throws RestClientException;
+    void deleteRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException;
 
     List<LegalCourtesyAddressWrapper> getCourtesyAddressByRecipient() throws RestClientException;
 
-    void postRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType, AddressVerification addressVerification) throws RestClientException;
+    void postRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException;
 }

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
@@ -186,7 +186,7 @@ public class B2BUserAttributesExternalClientImpl implements IPnWebUserAttributes
                 .toList();
     }
 
-    public void postRecipientLegalAddress(String senderId, LegalChannelType channelType, AddressVerification addressVerification) throws RestClientException {
+    public void postRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException {
         it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.LegalChannelType legalChannelType = deepCopy(channelType, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.LegalChannelType.class);
         it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.AddressVerification address = deepCopy(addressVerification, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.AddressVerification.class);
         legalApi.postRecipientLegalAddress(senderId, legalChannelType, address);

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
@@ -11,6 +11,7 @@ import it.pagopa.pn.client.b2b.pa.exception.PnB2bException;
 import it.pagopa.pn.client.b2b.pa.service.IPnWebUserAttributesClient;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyDigitalAddress;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.api.ConsentsApi;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.Consent;
@@ -194,10 +195,10 @@ public class B2BUserAttributesExternalClientImpl implements IPnWebUserAttributes
         courtesyApiAddressBook.deleteRecipientCourtesyAddress(senderId, deepCopy(channelType, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.CourtesyChannelType.class));
     }
 
-    public List<LegalCourtesyAddressWrapper> getCourtesyAddressByRecipient() throws RestClientException {
+    public List<CourtesyDigitalAddress> getCourtesyAddressByRecipient() throws RestClientException {
         return courtesyApiAddressBook.getCourtesyAddressByRecipient()
                 .stream()
-                .map(x -> deepCopy(x, LegalCourtesyAddressWrapper.class))
+                .map(x -> deepCopy(x, CourtesyDigitalAddress.class))
                 .toList();
     }
 

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/B2BUserAttributesExternalClientImpl.java
@@ -11,8 +11,6 @@ import it.pagopa.pn.client.b2b.pa.exception.PnB2bException;
 import it.pagopa.pn.client.b2b.pa.service.IPnWebUserAttributesClient;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyChannelType;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalChannelType;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.api.ConsentsApi;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.Consent;
@@ -174,7 +172,7 @@ public class B2BUserAttributesExternalClientImpl implements IPnWebUserAttributes
     }
 
 
-    public void deleteRecipientLegalAddress(String senderId, LegalChannelType channelType) throws RestClientException {
+    public void deleteRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException {
         legalApi.deleteRecipientLegalAddress(senderId, deepCopy(channelType, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.LegalChannelType.class));
     }
 
@@ -192,7 +190,7 @@ public class B2BUserAttributesExternalClientImpl implements IPnWebUserAttributes
         legalApi.postRecipientLegalAddress(senderId, legalChannelType, address);
     }
 
-    public void deleteRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType) throws RestClientException {
+    public void deleteRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException {
         courtesyApiAddressBook.deleteRecipientCourtesyAddress(senderId, deepCopy(channelType, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.CourtesyChannelType.class));
     }
 
@@ -203,7 +201,7 @@ public class B2BUserAttributesExternalClientImpl implements IPnWebUserAttributes
                 .toList();
     }
 
-    public void postRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType, AddressVerification addressVerification) throws RestClientException {
+    public void postRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException {
         it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.CourtesyChannelType courtesyChannelType = deepCopy(channelType, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.CourtesyChannelType.class);
         it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.AddressVerification address = deepCopy(addressVerification, it.pagopa.pn.client.b2b.generated.openapi.clients.userattributesb2b.model.AddressVerification.class);
         courtesyApiAddressBook.postRecipientCourtesyAddress(senderId, courtesyChannelType, address);

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
@@ -240,10 +240,10 @@ public class PnWebUserAttributesExternalClientImpl implements IPnWebUserAttribut
         addressesApi.deleteAddressV1(BffAddressType.COURTESY, senderId, BffChannelType.fromValue(channelType.getValue()));
     }
 
-    public List<LegalCourtesyAddressWrapper> getCourtesyAddressByRecipient() throws RestClientException {
+    public List<CourtesyDigitalAddress> getCourtesyAddressByRecipient() throws RestClientException {
         return addressesApi.getAddressesV1().stream()
                 .filter(item -> "COURTESY".equals(item.getAddressType()))
-                .map(item -> deepCopy(item, LegalCourtesyAddressWrapper.class))
+                .map(item -> deepCopy(item, CourtesyDigitalAddress.class))
                 .toList();
     }
 

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
@@ -227,7 +227,7 @@ public class PnWebUserAttributesExternalClientImpl implements IPnWebUserAttribut
                 .toList();
     }
 
-    public void postRecipientLegalAddress(String senderId, LegalChannelType channelType, AddressVerification addressVerification) throws RestClientException {
+    public void postRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException {
         BffAddressVerificationRequest bffAddressVerificationRequest = new BffAddressVerificationRequest().requestId(addressVerification.getRequestId())
                 .verificationCode(addressVerification.getVerificationCode()).value(addressVerification.getValue());
         addressesApi.createOrUpdateAddressV1(BffAddressType.LEGAL, senderId, BffChannelType.fromValue(channelType.getValue()), bffAddressVerificationRequest);

--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnWebUserAttributesExternalClientImpl.java
@@ -17,7 +17,10 @@ import it.pagopa.pn.client.b2b.pa.exception.IllegalConfigurationException;
 import it.pagopa.pn.client.b2b.pa.exception.PnB2bException;
 import it.pagopa.pn.client.b2b.pa.service.IPnWebUserAttributesClient;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.*;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyDigitalAddress;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalAndUnverifiedDigitalAddress;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.Consent;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.ConsentAction;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.consents.model.ConsentType;
@@ -216,7 +219,7 @@ public class PnWebUserAttributesExternalClientImpl implements IPnWebUserAttribut
         return userAddresses;
     }
 
-    public void deleteRecipientLegalAddress(String senderId, LegalChannelType channelType) throws RestClientException {
+    public void deleteRecipientLegalAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException {
         addressesApi.deleteAddressV1(BffAddressType.LEGAL, senderId, BffChannelType.fromValue(channelType.getValue()));
     }
 
@@ -233,7 +236,7 @@ public class PnWebUserAttributesExternalClientImpl implements IPnWebUserAttribut
         addressesApi.createOrUpdateAddressV1(BffAddressType.LEGAL, senderId, BffChannelType.fromValue(channelType.getValue()), bffAddressVerificationRequest);
     }
 
-    public void deleteRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType) throws RestClientException {
+    public void deleteRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType) throws RestClientException {
         addressesApi.deleteAddressV1(BffAddressType.COURTESY, senderId, BffChannelType.fromValue(channelType.getValue()));
     }
 
@@ -244,7 +247,7 @@ public class PnWebUserAttributesExternalClientImpl implements IPnWebUserAttribut
                 .toList();
     }
 
-    public void postRecipientCourtesyAddress(String senderId, CourtesyChannelType channelType, AddressVerification addressVerification) throws RestClientException {
+    public void postRecipientCourtesyAddress(String senderId, LegalCourtesyAddressWrapper.ChannelType channelType, AddressVerification addressVerification) throws RestClientException {
         BffAddressVerificationRequest bffAddressVerificationRequest = new BffAddressVerificationRequest().requestId(addressVerification.getRequestId())
                 .verificationCode(addressVerification.getVerificationCode()).value(addressVerification.getValue());
         addressesApi.createOrUpdateAddressV1(BffAddressType.COURTESY, senderId, BffChannelType.fromValue(channelType.getValue()), bffAddressVerificationRequest);

--- a/src/test/java/it/pagopa/pn/cucumber/steps/SharedSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/SharedSteps.java
@@ -25,7 +25,6 @@ import it.pagopa.pn.client.b2b.pa.service.impl.*;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableApiKey;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableBearerToken;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalChannelType;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.cucumber.steps.pa.notificationVersions.NotificationStepsInterface;
 import it.pagopa.pn.cucumber.steps.pa.notificationVersions.NotificationVersion;
@@ -369,7 +368,7 @@ public class SharedSteps {
         for (int i = 0; i < numberOfNotification; i++) {
             Thread t = new Thread(() -> {
                 notificationStepsInterface.sendNotification(getWorkFlowWait(), NOTIFICATION_STATUS_ACCEPTED, VALIDATION_STATUS);
-                notificationStepsInterface.waitForTimelineElement(notificationIun, COMPLETELY_UNREACHABLE, 33);
+                notificationStepsInterface.waitForTimelineElement(COMPLETELY_UNREACHABLE, 33);
                 notificationsCounter.getAndIncrement();
             });
             threadList.add(t);
@@ -688,7 +687,7 @@ public class SharedSteps {
         try {
             List<LegalCourtesyAddressWrapper> legalAddressByRecipient = this.iPnWebUserAttributesClient.getLegalAddressByRecipient();
             if (legalAddressByRecipient != null && !legalAddressByRecipient.isEmpty()) {
-                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress("default", LegalChannelType.PEC);
+                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress("default", LegalCourtesyAddressWrapper.ChannelType.PEC);
                 log.info("PEC FOUND AND DELETED");
             }
         } catch (HttpStatusCodeException httpStatusCodeException) {
@@ -705,7 +704,7 @@ public class SharedSteps {
         selectUser(user);
         try {
             this.iPnWebUserAttributesClient.getLegalAddressByRecipient().stream()
-                    .filter(address -> LegalChannelType.PEC.equals(address.getChannelType()))
+                    .filter(address -> LegalCourtesyAddressWrapper.ChannelType.PEC.getValue().equals(address.getChannelType().getValue()))
                     .findAny()
                     .orElseThrow(() -> AssertionFailureBuilder.assertionFailure().message("PEC NOT FOUND!").build());
         } catch (Exception exc) {
@@ -714,7 +713,7 @@ public class SharedSteps {
         }
     }
 
-    @And("viene verificata la presenza di {int} recapiti di cortesia inseriti per l'utente {string}")
+    @And("viene verificata la presenza di {int} recapit(o)(i) di cortesia inserit(o)(i) per l'utente {string}")
     public void viewedCourtesyAddress(int expectedItems, String user) {
         selectUser(user);
         List<LegalCourtesyAddressWrapper> courtesyAddressByRecipient = this.iPnWebUserAttributesClient.getCourtesyAddressByRecipient();
@@ -1197,7 +1196,7 @@ public class SharedSteps {
     }
 
     public List<String> getDatiPagamentoVersionamento(Integer destinatario, Integer pagamento) {
-        return getNotificationStepInterface().getDatiPagamento(notificationIun, destinatario, pagamento);
+        return getNotificationStepInterface().getDatiPagamento(destinatario, pagamento);
     }
 
     public static void threadWait(int wait) {

--- a/src/test/java/it/pagopa/pn/cucumber/steps/SharedSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/SharedSteps.java
@@ -25,6 +25,7 @@ import it.pagopa.pn.client.b2b.pa.service.impl.*;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableApiKey;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableBearerToken;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyDigitalAddress;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.UserAddresses;
 import it.pagopa.pn.cucumber.steps.pa.notificationVersions.NotificationStepsInterface;
 import it.pagopa.pn.cucumber.steps.pa.notificationVersions.NotificationVersion;
@@ -716,7 +717,7 @@ public class SharedSteps {
     @And("viene verificata la presenza di {int} recapit(o)(i) di cortesia inserit(o)(i) per l'utente {string}")
     public void viewedCourtesyAddress(int expectedItems, String user) {
         selectUser(user);
-        List<LegalCourtesyAddressWrapper> courtesyAddressByRecipient = this.iPnWebUserAttributesClient.getCourtesyAddressByRecipient();
+        List<CourtesyDigitalAddress> courtesyAddressByRecipient = this.iPnWebUserAttributesClient.getCourtesyAddressByRecipient();
         Assertions.assertEquals(expectedItems, courtesyAddressByRecipient.size(), "Error retrieving the courtesy addresses!");
     }
 

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsInterface.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsInterface.java
@@ -58,9 +58,9 @@ public interface NotificationStepsInterface {
 
     void addIuvGpdToDestinatario(String denominazione, String iuvGpd, Integer paymentIndex);
 
-    List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento);
+    List<String> getDatiPagamento(Integer destinatario, Integer pagamento);
 
-    void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts);
+    void waitForTimelineElement(String timelineElementCategory, Integer attempts);
 
     void getNotificationRequestStatus(String requestId);
 

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV1.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV1.java
@@ -268,19 +268,19 @@ public class NotificationStepsV1 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotification fullSentNotification = b2bClient.getSentNotificationV1(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotification fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayment()).getCreditorTaxId(),
                 Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayment()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElement timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotification fsn = b2bClient.getSentNotificationV1(iun);
+            FullSentNotification fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())
@@ -306,8 +306,7 @@ public class NotificationStepsV1 implements NotificationStepsInterface {
 
     @Override
     public void checkTaxonomyCode() {
-        String iun = sharedSteps.getNotificationIun();
-        FullSentNotification fullSentNotification = b2bClient.getSentNotificationV1(iun);
+        FullSentNotification fullSentNotification = getFullSentNotificationVersioned();
         assertThat(fullSentNotification.getTaxonomyCode())
                 .as("Il taxonomyCode nella notifica inviata non dovrebbe essere nullo")
                 .isNotNull();

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV2.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV2.java
@@ -269,19 +269,19 @@ public class NotificationStepsV2 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotificationV20 fullSentNotification = b2bClient.getSentNotificationV2(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotificationV20 fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayment()).getCreditorTaxId(),
                 Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayment()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElementV20 timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotificationV20 fsn = b2bClient.getSentNotificationV2(iun);
+            FullSentNotificationV20 fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())
@@ -307,8 +307,7 @@ public class NotificationStepsV2 implements NotificationStepsInterface {
 
     @Override
     public void checkTaxonomyCode() {
-        String iun = sharedSteps.getNotificationIun();
-        FullSentNotificationV20 fullSentNotification = b2bClient.getSentNotificationV2(iun);
+        FullSentNotificationV20 fullSentNotification = getFullSentNotificationVersioned();
         assertThat(fullSentNotification.getTaxonomyCode())
                 .as("Il taxonomyCode nella notifica inviata non dovrebbe essere nullo")
                 .isNotNull();

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV21.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV21.java
@@ -276,7 +276,7 @@ public class NotificationStepsV21 implements NotificationStepsInterface {
 
             }
         }
-        uploadNotification(null);
+        b2bClient.sendNewNotificationV21(notificationRequest);
     }
 
     @Override

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV21.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV21.java
@@ -289,19 +289,19 @@ public class NotificationStepsV21 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotificationV21 fullSentNotification = b2bClient.getSentNotificationV21(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotificationV21 fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getCreditorTaxId(),
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElementV20 timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotificationV21 fsn = b2bClient.getSentNotificationV21(iun);
+            FullSentNotificationV21 fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())
@@ -327,8 +327,7 @@ public class NotificationStepsV21 implements NotificationStepsInterface {
 
     @Override
     public void checkTaxonomyCode() {
-        String iun = sharedSteps.getNotificationIun();
-        FullSentNotificationV21 fullSentNotification = b2bClient.getSentNotificationV21(iun);
+        FullSentNotificationV21 fullSentNotification = getFullSentNotificationVersioned();
         assertThat(fullSentNotification.getTaxonomyCode())
                 .as("Il taxonomyCode nella notifica inviata non dovrebbe essere nullo")
                 .isNotNull();

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV23.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV23.java
@@ -274,7 +274,7 @@ public class NotificationStepsV23 implements NotificationStepsInterface {
 
             }
         }
-        uploadNotification(null);
+        b2bClient.sendNewNotificationV23(notificationRequest);
     }
 
     @Override

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV23.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV23.java
@@ -287,19 +287,19 @@ public class NotificationStepsV23 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotificationV23 fullSentNotification = b2bClient.getSentNotificationV23(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotificationV23 fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getCreditorTaxId(),
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElementV23 timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotificationV23 fsn = b2bClient.getSentNotificationV23(iun);
+            FullSentNotificationV23 fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())
@@ -325,8 +325,7 @@ public class NotificationStepsV23 implements NotificationStepsInterface {
 
     @Override
     public void checkTaxonomyCode() {
-        String iun = sharedSteps.getNotificationIun();
-        FullSentNotificationV23 fullSentNotification = b2bClient.getSentNotificationV23(iun);
+        FullSentNotificationV23 fullSentNotification = getFullSentNotificationVersioned();
         assertThat(fullSentNotification.getTaxonomyCode())
                 .as("Il taxonomyCode nella notifica inviata non dovrebbe essere nullo")
                 .isNotNull();

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV24.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV24.java
@@ -48,7 +48,7 @@ public class NotificationStepsV24 implements NotificationStepsInterface {
 
     @Override
     public Object getFullSentNotification() {
-        return b2bClient.getSentNotificationV24(sharedSteps.getNotificationIun());
+        return b2bClient.getSentNotificationV26(sharedSteps.getNotificationIun());
     }
 
     private FullSentNotificationV26 getFullSentNotificationVersioned() {
@@ -307,19 +307,19 @@ public class NotificationStepsV24 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotificationV26 fullSentNotification = b2bClient.getSentNotificationV26(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotificationV26 fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getCreditorTaxId(),
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElementV26 timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotificationV26 fsn = b2bClient.getSentNotificationV26(iun);
+            FullSentNotificationV26 fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())
@@ -345,8 +345,7 @@ public class NotificationStepsV24 implements NotificationStepsInterface {
 
     @Override
     public void checkTaxonomyCode() {
-        String iun = sharedSteps.getNotificationIun();
-        FullSentNotificationV26 fullSentNotification = b2bClient.getSentNotificationV26(iun);
+        FullSentNotificationV26 fullSentNotification = getFullSentNotificationVersioned();
         assertThat(fullSentNotification.getTaxonomyCode())
                 .as("Il taxonomyCode nella notifica inviata non dovrebbe essere null")
                 .isNotNull();

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV24.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV24.java
@@ -294,7 +294,7 @@ public class NotificationStepsV24 implements NotificationStepsInterface {
 
             }
         }
-        uploadNotification(null);
+        b2bClient.sendNewNotificationV24(notificationRequest);
     }
 
     @Override

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV25.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV25.java
@@ -293,7 +293,7 @@ public class NotificationStepsV25 implements NotificationStepsInterface {
 
             }
         }
-        uploadNotification(null);
+        b2bClient.sendNewNotificationV25(notificationRequest);
     }
 
     @Override

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV25.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/notificationVersions/NotificationStepsV25.java
@@ -306,19 +306,19 @@ public class NotificationStepsV25 implements NotificationStepsInterface {
     }
 
     @Override
-    public List<String> getDatiPagamento(String iun, Integer destinatario, Integer pagamento) {
-        FullSentNotificationV27 fullSentNotification = b2bClient.getSentNotificationV27(iun);
+    public List<String> getDatiPagamento(Integer destinatario, Integer pagamento) {
+        FullSentNotificationV27 fullSentNotification = getFullSentNotificationVersioned();
         return Arrays.asList(
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getCreditorTaxId(),
                 Objects.requireNonNull(Objects.requireNonNull(fullSentNotification.getRecipients().get(destinatario).getPayments()).get(pagamento).getPagoPa()).getNoticeCode());
     }
 
     @Override
-    public void waitForTimelineElement(String iun, String timelineElementCategory, Integer attempts) {
+    public void waitForTimelineElement(String timelineElementCategory, Integer attempts) {
         TimelineElementV27 timelineElement = null;
         for (int i = 0; i < attempts; i++) {
             threadWait(sharedSteps.getWorkFlowWait());
-            FullSentNotificationV27 fsn = b2bClient.getSentNotificationV27(iun);
+            FullSentNotificationV27 fsn = getFullSentNotificationVersioned();
             log.info("NOTIFICATION_TIMELINE: " + fsn.getTimeline());
             timelineElement = fsn.getTimeline()
                     .stream().filter(elem -> Objects.requireNonNull(elem.getCategory().getValue())

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/webhookVersions/WebhookStepsV24.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/webhookVersions/WebhookStepsV24.java
@@ -54,7 +54,7 @@ public class WebhookStepsV24 implements WebhookStepsInterface {
 
     @Override
     public Object getFullSentNotification() {
-        return b2bClient.getSentNotificationV26(sharedSteps.getNotificationIun());
+        return b2bClient.getSentNotificationV24(sharedSteps.getNotificationIun());
     }
 
     private FullSentNotificationV24 getFullSentNotificationVersioned() {

--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
@@ -24,7 +24,10 @@ import it.pagopa.pn.client.b2b.pa.service.impl.PnExternalServiceClientImpl;
 import it.pagopa.pn.client.b2b.pa.service.impl.PnWebUserAttributesExternalClientImpl;
 import it.pagopa.pn.client.b2b.pa.service.utils.SettableBearerToken;
 import it.pagopa.pn.client.b2b.pa.wrapper.LegalCourtesyAddressWrapper;
-import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.*;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.AddressVerification;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.CourtesyDigitalAddress;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalAndUnverifiedDigitalAddress;
+import it.pagopa.pn.client.web.generated.openapi.clients.externalUserAttributes.addressBook.model.LegalChannelType;
 import it.pagopa.pn.cucumber.steps.SharedSteps;
 import it.pagopa.pn.cucumber.steps.pa.utilityVersions.B2bUtils;
 import it.pagopa.pn.cucumber.utils.DataTest;
@@ -629,12 +632,12 @@ public class RicezioneNotificheWebSteps {
 
     @When("viene richiesto l'inserimento del numero di telefono {string}")
     public void vieneRichiestoLInserimentoDelNumeroDiTelefono(String phone) {
-        postRecipientCourtesyAddress("default", phone, CourtesyChannelType.SMS, "00000", false);
+        postRecipientCourtesyAddress("default", phone, LegalCourtesyAddressWrapper.ChannelType.SMS, "00000", false);
     }
 
     @When("viene richiesto l'inserimento del email di cortesia {string}")
     public void vieneRichiestoLInserimentoDelEmailDiCortesia(String email) {
-        postRecipientCourtesyAddress("default", email, CourtesyChannelType.EMAIL, "00000", false);
+        postRecipientCourtesyAddress("default", email, LegalCourtesyAddressWrapper.ChannelType.EMAIL, "00000", false);
     }
 
     @And("viene inserito un recapito legale {string} per il comune {string}")
@@ -658,25 +661,25 @@ public class RicezioneNotificheWebSteps {
     @And("viene richiesto l'inserimento del email di cortesia {string} per il comune {string}")
     public void vieneRichiestoLInserimentoDelEmailDiCortesiaDalComune(String email, String pa) {
         String senderIdPa = getSenderIdPa(pa);
-        postRecipientCourtesyAddress(senderIdPa, email, CourtesyChannelType.EMAIL, "00000", false);
+        postRecipientCourtesyAddress(senderIdPa, email, LegalCourtesyAddressWrapper.ChannelType.EMAIL, "00000", false);
     }
 
     @And("viene inserita l'email di cortesia {string} per il comune {string}")
     public void vieneInseritaEmailDiCortesiaDalComune(String email, String pa) {
         String senderIdPa = getSenderIdPa(pa);
-        postRecipientCourtesyAddress(senderIdPa, email, CourtesyChannelType.EMAIL, null, true);
+        postRecipientCourtesyAddress(senderIdPa, email, LegalCourtesyAddressWrapper.ChannelType.EMAIL, null, true);
     }
 
     @When("viene richiesto l'inserimento del numero di telefono {string} per il comune {string}")
     public void vieneRichiestoLInserimentoDelNumeroDiTelefono(String phone, String pa) {
         String senderIdPa = getSenderIdPa(pa);
-        postRecipientCourtesyAddress(senderIdPa, phone, CourtesyChannelType.SMS, "00000", false);
+        postRecipientCourtesyAddress(senderIdPa, phone, LegalCourtesyAddressWrapper.ChannelType.SMS, "00000", false);
     }
 
-    private void postRecipientCourtesyAddress(String senderId, String addressVerification, CourtesyChannelType type, String verificationCode, boolean inserimento) {
+    private void postRecipientCourtesyAddress(String senderId, String addressVerification, LegalCourtesyAddressWrapper.ChannelType type, String verificationCode, boolean inserimento) {
         try {
             if (inserimento) {
-                this.iPnWebUserAttributesClient.postRecipientCourtesyAddress(senderId, CourtesyChannelType.EMAIL, (new AddressVerification().value(addressVerification)));
+                this.iPnWebUserAttributesClient.postRecipientCourtesyAddress(senderId, LegalCourtesyAddressWrapper.ChannelType.EMAIL, (new AddressVerification().value(addressVerification)));
                 verificationCode = this.externalClient.getVerificationCode(addressVerification);
             }
             this.iPnWebUserAttributesClient.postRecipientCourtesyAddress(senderId, type, (new AddressVerification().value(addressVerification).verificationCode(verificationCode)));
@@ -712,7 +715,7 @@ public class RicezioneNotificheWebSteps {
         String senderIdPa = getSenderIdPa(pa);
 
         try {
-            this.iPnWebUserAttributesClient.deleteRecipientCourtesyAddress(senderIdPa, CourtesyChannelType.EMAIL);
+            this.iPnWebUserAttributesClient.deleteRecipientCourtesyAddress(senderIdPa, LegalCourtesyAddressWrapper.ChannelType.EMAIL);
         } catch (HttpStatusCodeException httpStatusCodeException) {
             sharedSteps.setNotificationError(httpStatusCodeException);
         }
@@ -834,7 +837,7 @@ public class RicezioneNotificheWebSteps {
         Assertions.assertDoesNotThrow(() -> {
             List<LegalCourtesyAddressWrapper> legalAddressByRecipient = this.iPnWebUserAttributesClient.getLegalAddressByRecipient();
             if (legalAddressByRecipient != null && !legalAddressByRecipient.isEmpty()) {
-                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalChannelType.SERCQ);
+                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalCourtesyAddressWrapper.ChannelType.SERCQ);
                 log.info("SERCQ DISABLED");
             }
         });
@@ -961,7 +964,7 @@ public class RicezioneNotificheWebSteps {
     public void vieneRimossaSePresenteLaPecDiPiattaformaDi(String pa) {
         String senderId = getSenderIdPa(pa);
         Assertions.assertDoesNotThrow(() -> {
-            this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalChannelType.PEC);
+            this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalCourtesyAddressWrapper.ChannelType.PEC);
             log.info("PEC FOUND AND DELETED");
         }, "PEC NOT FOUND");
     }
@@ -973,7 +976,7 @@ public class RicezioneNotificheWebSteps {
             if (legalAddressByRecipient != null && !legalAddressByRecipient.isEmpty()) {
                 legalAddressByRecipient
                         .forEach(address -> {
-                            this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(address.getSenderId(), address.getChannelType());
+                            this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(address.getSenderId(), LegalCourtesyAddressWrapper.ChannelType.valueOf(address.getChannelType().getValue()));
                             log.info("Cancellato indirizzo di tipo " + address.getChannelType() + " per il comune " + address.getSenderId());
                         });
             }
@@ -981,7 +984,7 @@ public class RicezioneNotificheWebSteps {
             if (courtesyDigitalAddresses != null && !courtesyDigitalAddresses.isEmpty()) {
                 courtesyDigitalAddresses
                         .forEach(address -> {
-                            this.iPnWebUserAttributesClient.deleteRecipientCourtesyAddress(address.getSenderId(), address.getChannelType());
+                            this.iPnWebUserAttributesClient.deleteRecipientCourtesyAddress(address.getSenderId(), LegalCourtesyAddressWrapper.ChannelType.valueOf(address.getChannelType().getValue()));
                             log.info("Cancellato indirizzo di cortesia di tipo " + address.getChannelType() + " per il comune " + address.getSenderId());
                         });
             }

--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
@@ -688,10 +688,10 @@ public class RicezioneNotificheWebSteps {
     private void postRecipientLegalAddress(String senderIdPa, String addressVerification, String verificationCode, boolean inserimento) {
         try {
             if (inserimento) {
-                this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalChannelType.PEC, (new AddressVerification().value(addressVerification)));
+                this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalCourtesyAddressWrapper.ChannelType.PEC, (new AddressVerification().value(addressVerification)));
                 verificationCode = this.externalClient.getVerificationCode(addressVerification);
             }
-            this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalChannelType.PEC, (new AddressVerification().value(addressVerification).verificationCode(verificationCode)));
+            this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalCourtesyAddressWrapper.ChannelType.PEC, (new AddressVerification().value(addressVerification).verificationCode(verificationCode)));
         } catch (HttpStatusCodeException httpStatusCodeException) {
             sharedSteps.setNotificationError(httpStatusCodeException);
         }
@@ -704,7 +704,7 @@ public class RicezioneNotificheWebSteps {
                 .verificationCode(code[0]);
 
         Assertions.assertThrows(HttpStatusCodeException.class,
-                () -> this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalChannelType.PEC, verification));
+                () -> this.iPnWebUserAttributesClient.postRecipientLegalAddress(senderIdPa, LegalCourtesyAddressWrapper.ChannelType.PEC, verification));
     }
 
     @And("viene cancellata l'email di cortesia per il comune {string}")
@@ -825,7 +825,7 @@ public class RicezioneNotificheWebSteps {
 
     private void postRecipientLegalAddressSercq(String senderIdPa, String address) {
         Assertions.assertDoesNotThrow(() -> this.iPnWebUserAttributesClient.postRecipientLegalAddress(
-                senderIdPa, LegalChannelType.SERCQ, (new AddressVerification().value(address))));
+                senderIdPa, LegalCourtesyAddressWrapper.ChannelType.SERCQ_SEND, (new AddressVerification().value(address))));
     }
 
     @And("viene disabilitato il servizio SERCQ SEND per il comune di {string}")
@@ -882,7 +882,7 @@ public class RicezioneNotificheWebSteps {
 
         switch (act) {
             case "disabilitato" -> Assertions.assertFalse(exists, "Sercq risulta abilitato per il comune: " + pa);
-            case "abilitato" -> Assertions.assertTrue(exists, "Sercq risulta disabilitato per il comune: " + pa);
+            case "abilitato" -> Assertions.assertFalse(exists, "Sercq risulta disabilitato per il comune: " + pa);
             default ->
                     throw new IllegalArgumentException("Valore di 'act' non valido: " + act + ". I valori consentiti sono 'abilitato' o 'disabilitato'.");
         }

--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
@@ -837,7 +837,7 @@ public class RicezioneNotificheWebSteps {
         Assertions.assertDoesNotThrow(() -> {
             List<LegalCourtesyAddressWrapper> legalAddressByRecipient = this.iPnWebUserAttributesClient.getLegalAddressByRecipient();
             if (legalAddressByRecipient != null && !legalAddressByRecipient.isEmpty()) {
-                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalCourtesyAddressWrapper.ChannelType.SERCQ);
+                this.iPnWebUserAttributesClient.deleteRecipientLegalAddress(senderId, LegalCourtesyAddressWrapper.ChannelType.SERCQ_SEND);
                 log.info("SERCQ DISABLED");
             }
         });

--- a/src/test/resources/it/pagopa/pn/cucumber/ApiB2bDestinatariStrutturati.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/ApiB2bDestinatariStrutturati.feature
@@ -344,6 +344,8 @@ Feature: Api b2b per destinatari strutturati
 
   @legalFact @useB2B @b2bDestinatariStrutturati
   Scenario: [B2B-RECIPIENT_LEGALFACT_3] Invio notifica e download atto opponibile PEC_RECEIPT_scenario positivo
+    Given si predispone addressbook per l'utente "CucumberSpa"
+    And viene disabilitato il servizio SERCQ SEND per il comune di "Comune_1"
     Given viene generata una nuova notifica
       | subject            | invio notifica con cucumber |
       | senderDenomination | Comune di milano            |

--- a/src/test/resources/it/pagopa/pn/cucumber/ApiB2bDestinatariStrutturati.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/ApiB2bDestinatariStrutturati.feature
@@ -346,7 +346,7 @@ Feature: Api b2b per destinatari strutturati
   Scenario: [B2B-RECIPIENT_LEGALFACT_3] Invio notifica e download atto opponibile PEC_RECEIPT_scenario positivo
     Given si predispone addressbook per l'utente "CucumberSpa"
     And viene disabilitato il servizio SERCQ SEND per il comune di "Comune_1"
-    Given viene generata una nuova notifica
+    And viene generata una nuova notifica
       | subject            | invio notifica con cucumber |
       | senderDenomination | Comune di milano            |
     And destinatario CucumberSpa

--- a/src/test/resources/it/pagopa/pn/cucumber/Radd/RaddAlternative/RaddAlternative.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/Radd/RaddAlternative/RaddAlternative.feature
@@ -1335,13 +1335,13 @@ Feature: Radd Alternative
 
 # AUDIT cases
 
-  @raddAlt @raddAltLog
+  @raddAlt @raddAltLog @uat #In test l' ingestion è disabilitata, non si riceverà nessun audit-log
   Scenario: [RADD-ALT_AUDIT_LOG-96] Scansione QR code o IUN e verifica auditlog AUD_RADD_ACTTRAN
     When viene verificato che esiste un audit log "AUD_RADD_ACTTRAN" in "10y"
     Then viene verificato che esiste un audit log "AUD_RADD_ACTTRAN" con messaggio "[AUD_RADD_ACTTRAN] FAILURE"
     Then viene verificato che esiste un audit log "AUD_RADD_ACTTRAN" senza messaggio con "error null"
 
-  @raddAlt @raddAltLog
+  @raddAlt @raddAltLog @uat #In test l' ingestion è disabilitata, non si riceverà nessun audit-log
   Scenario Outline: [RADD-ALT_AUDIT_LOG-97] Scansione QR code o IUN e verifica auditlog AUD_RADD_ACTTRAN
     When viene verificato che esiste un audit log "<audit-log>" in "10y"
     Then viene verificato che esiste un audit log "<audit-log>" con messaggio "operationId="
@@ -1352,7 +1352,7 @@ Feature: Radd Alternative
       | AUD_RADD_AORTRAN |
 
   #Copre scenari tutti i scenari di test 43-44-45-46
-  @raddAlt @raddAltLog
+  @raddAlt @raddAltLog @uat #In test l' ingestion è disabilitata, non si riceverà nessun audit-log
   Scenario Outline: [RADD-ALT_AUDIT_LOG-42] Scansione QR code o IUN e verifica auditlog AUD_RADD_ACTINQUIRY
     Then viene verificato che esiste un audit log "<audit-log>" in "10y"
     Examples:

--- a/src/test/resources/it/pagopa/pn/cucumber/annullamentoNotifica/AnnullamentoNotificheB2b.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/annullamentoNotifica/AnnullamentoNotificheB2b.feature
@@ -325,7 +325,7 @@ Feature: annullamento notifiche b2b
     When la notifica può essere annullata dal sistema tramite codice IUN
     Then vengono letti gli eventi fino all'elemento di timeline della notifica "NOTIFICATION_CANCELLATION_REQUEST"
 
-  @Annullamento
+  @Annullamento @uat #In test l' ingestion è disabilitata, non si riceverà nessun audit-log
   Scenario Outline: [B2B-PA-ANNULLAMENTO_15] AuditLog: verifica presenza evento post annullamento notifica
     Given viene generata una nuova notifica
       | subject            | invio notifica con cucumber |

--- a/src/test/resources/it/pagopa/pn/cucumber/baseFunction/validation/SyncValidation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/baseFunction/validation/SyncValidation.feature
@@ -1039,7 +1039,7 @@ Feature: verifica validazione sincrona
     When la notifica viene inviata tramite api b2b dal "Comune_Multi" con allegato uguale all'allegato di pagamento
     Then l'operazione ha prodotto un errore con status code "400" con messaggio di errore "Same attachment compares more then once in the same request"
 
-
+  @validation
   Scenario: [B2B-PA-SYNC_VALIDATION_71] Invio notifica multidestinatario con allegato uguale all'allegato di pagamento - PN-10162
     Given viene generata una nuova notifica
       | subject            | invio notifica con cucumber |

--- a/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPGDigitaleNR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPGDigitaleNR.feature
@@ -48,7 +48,7 @@ Feature: avanzamento b2b notifica  digitale PG con chiamata a National Registry 
       | senderDenomination | Comune di milano            |
     And destinatario
       | denomination    | Test digitale ok |
-      | taxId           | 00883601007      |
+      | taxId           | 29527800386      |
       | digitalDomicile | NULL             |
       | recipientType   | PG               |
     When la notifica viene inviata tramite api b2b dal "Comune_1" e si attende che lo stato diventi "ACCEPTED"
@@ -58,7 +58,7 @@ Feature: avanzamento b2b notifica  digitale PG con chiamata a National Registry 
       | details                      | NOT_NULL                                                |
       | details_responseStatus       | OK                                                      |
       | details_sendingReceipts      | [{"id": null, "system": null}]                          |
-      | details_digitalAddress       | {"address": "example2@OK-pecSuccess.it", "type": "PEC"} |
+      | details_digitalAddress       | {"address": "mock@pec.interno.it", "type": "PEC"} |
       | details_recIndex             | 0                                                       |
       | details_digitalAddressSource | GENERAL                                                 |
       | details_sentAttemptMade      | 0                                                       |

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflow890/AvanzamentoNotificheB2bPFPGMultiAnalogico890.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflow890/AvanzamentoNotificheB2bPFPGMultiAnalogico890.feature
@@ -129,9 +129,12 @@ Feature: avanzamento b2b notifica multi destinatario analogico 890
     And destinatario Mario Gherkin e:
       | digitalDomicile         | NULL       |
       | physicalAddress_address | Via@ok_890 |
-    And destinatario Mario Cucumber e:
-      | digitalDomicile         | NULL       |
-      | physicalAddress_address | Via@ok_890 |
+    And destinatario
+      | denomination    | PG Non Censito |
+      | recipientType   | PG             |
+      | taxId           | 02455090981   |
+      | digitalDomicile | NULL           |
+      | physicalAddress | Via@ok_890           |
     When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     Then vengono letti gli eventi fino all'elemento di timeline della notifica "ANALOG_SUCCESS_WORKFLOW" per l'utente 1
     And vengono letti gli eventi fino all'elemento di timeline della notifica "ANALOG_SUCCESS_WORKFLOW" per l'utente 0


### PR DESCRIPTION
Fix per SercQ (ora utilizza LegalCourtesyAddressWrapper) -> RUN 1724 in test 100% passed
Inoltre il metodo viewedSercqPerEnte 
era implementato male
- fix ClassCastException su testWebhookV24
- adeguamento classi notificationSteps (rese conformi tra loro)