### PR TITLE
QA-8148-split-NRT

### DIFF
--- a/interop-qa-tests/src/main/java/it/pagopa/interop/agreement/service/impl/EServiceApiClientImpl.java
+++ b/interop-qa-tests/src/main/java/it/pagopa/interop/agreement/service/impl/EServiceApiClientImpl.java
@@ -140,7 +140,7 @@ public class EServiceApiClientImpl implements IEServiceClient {
     }
 
     public File getEServiceDocumentById(UUID eServiceId, UUID descriptorId, UUID documentId) {
-        return eservicesApi.getEServiceDocumentById(eServiceId.toString(), descriptorId.toString(), documentId.toString());
+        return eservicesApi.getEServiceDocumentById(eServiceId, descriptorId, documentId);
     }
 
     public EServiceDoc updateEServiceDocumentById(UUID eServiceId, UUID descriptorId, UUID documentId, UpdateEServiceDescriptorDocumentSeed updateEServiceDescriptorDocumentSeed) {

--- a/interop-qa-tests/src/main/java/it/pagopa/interop/delegate/service/impl/ConsumerDelegationsApiClientImpl.java
+++ b/interop-qa-tests/src/main/java/it/pagopa/interop/delegate/service/impl/ConsumerDelegationsApiClientImpl.java
@@ -73,9 +73,10 @@ public class ConsumerDelegationsApiClientImpl implements IConsumerDelegationsApi
     }
 
     @Override
+    // TODO 24/06/2025 modificare firma così che venga passato un UUID
     public void revokeConsumerDelegation(String delegationId)
         throws RestClientException {
-        consumerDelegationsApi.revokeConsumerDelegation(delegationId);
+        consumerDelegationsApi.revokeConsumerDelegation(UUID.fromString(delegationId));
     }
 
     @Override

--- a/interop-qa-tests/src/main/java/it/pagopa/interop/delegate/service/impl/ProducerDelegationsApiClientImpl.java
+++ b/interop-qa-tests/src/main/java/it/pagopa/interop/delegate/service/impl/ProducerDelegationsApiClientImpl.java
@@ -57,8 +57,9 @@ public class ProducerDelegationsApiClientImpl implements IProducerDelegationsApi
     }
 
     @Override
+    // TODO 24/06/2025 modificare firma così che venga passato un UUID
     public void revokeProducerDelegation(String delegationId) {
-        producerDelegationsApi.revokeProducerDelegation(delegationId);
+        producerDelegationsApi.revokeProducerDelegation(UUID.fromString(delegationId));
     }
 
     @Override

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Agreement1Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Agreement1Test.java
@@ -23,6 +23,6 @@ import org.junit.platform.suite.api.Suite;
         @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
 })
 @ExcludeTags({"wait_for_fix"})
-@IncludeTags({"agreement"})
-public class AgreementTest {
+@IncludeTags({"agreement-1"})
+public class Agreement1Test {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Agreement2Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Agreement2Test.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"agreement-2"})
+public class Agreement2Test {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementCrudTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementCrudTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"agreement-crud"})
+public class AgreementCrudTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementDocumentTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementDocumentTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"agreement-document"})
+public class AgreementDocumentTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementListTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementListTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"agreement-list"})
+public class AgreementListTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AgreementTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"agreement"})
+public class AgreementTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AttributeTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/AttributeTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"attribute"})
+public class AttributeTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientCrudTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientCrudTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"client-crud"})
+public class ClientCrudTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientKeyTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientKeyTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"client-key"})
+public class ClientKeyTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientPurposeTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientPurposeTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"client-purpose"})
+public class ClientPurposeTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientUserTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/ClientUserTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"client-user"})
+public class ClientUserTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/DescriptorTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/DescriptorTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"descriptor"})
+public class DescriptorTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/DocumentTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/DocumentTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"document"})
+public class DocumentTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/EServiceTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/EServiceTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"eservice"})
+public class EServiceTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Purpose1Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Purpose1Test.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose-1"})
+public class Purpose1Test {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Purpose2Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Purpose2Test.java
@@ -23,6 +23,6 @@ import org.junit.platform.suite.api.Suite;
         @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
 })
 @ExcludeTags({"wait_for_fix"})
-@IncludeTags({"purpose"})
-public class PurposeTest {
+@IncludeTags({"purpose-2"})
+public class Purpose2Test {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeCreationTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeCreationTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose-creation"})
+public class PurposeCreationTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeDailyCallsUpdateTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeDailyCallsUpdateTest.java
@@ -23,6 +23,6 @@ import org.junit.platform.suite.api.Suite;
         @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
 })
 @ExcludeTags({"wait_for_fix"})
-@IncludeTags({"purpose"})
-public class PurposeTest {
+@IncludeTags({"daily_calls_update_request"})
+public class PurposeDailyCallsUpdateTest {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeLatestRiskAnalysisTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeLatestRiskAnalysisTest.java
@@ -23,6 +23,6 @@ import org.junit.platform.suite.api.Suite;
         @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
 })
 @ExcludeTags({"wait_for_fix"})
-@IncludeTags({"purpose"})
-public class PurposeTest {
+@IncludeTags({"purpose_latest_risk_analysis"})
+public class PurposeLatestRiskAnalysisTest {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeListTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeListTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose-list"})
+public class PurposeListTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeModeTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeModeTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose-mode"})
+public class PurposeModeTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeRiskAnalysisTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeRiskAnalysisTest.java
@@ -23,6 +23,6 @@ import org.junit.platform.suite.api.Suite;
         @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
 })
 @ExcludeTags({"wait_for_fix"})
-@IncludeTags({"purpose"})
-public class PurposeTest {
+@IncludeTags({"purpose_risk_analysis"})
+public class PurposeRiskAnalysisTest {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose", "daily_calls_update_request", "purpose_latest_risk_analysis", "purpose_risk_analysis"})
+public class PurposeTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeVersionTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/PurposeVersionTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"purpose-version"})
+public class PurposeVersionTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Tenant1Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Tenant1Test.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"tenant-1"})
+public class Tenant1Test {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantAssignTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantAssignTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"tenant-assign"})
+public class TenantAssignTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantListingTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantListingTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"tenant-listing"})
+public class TenantListingTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantRevokeTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/TenantRevokeTest.java
@@ -1,0 +1,28 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+@IncludeTags({"tenant-revoke"})
+public class TenantRevokeTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1Test.java
@@ -24,6 +24,6 @@ import org.junit.platform.suite.api.Suite;
 })
 @ExcludeTags({"wait_for_fix"})
 //@IncludeTags({"voucher_wait_for_fix"})
-@IncludeTags({"voucher"})
-public class VoucherTest {
+@IncludeTags({"voucher-1"})
+public class Voucher1Test {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1aTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1aTest.java
@@ -1,0 +1,29 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+//@IncludeTags({"voucher_wait_for_fix"})
+@IncludeTags({"voucher-1a"})
+public class Voucher1aTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1axTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1axTest.java
@@ -24,6 +24,6 @@ import org.junit.platform.suite.api.Suite;
 })
 @ExcludeTags({"wait_for_fix"})
 //@IncludeTags({"voucher_wait_for_fix"})
-@IncludeTags({"voucher-1a"})
-public class Voucher1aTest {
+@IncludeTags({"voucher-1ax"})
+public class Voucher1axTest {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1ayTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1ayTest.java
@@ -1,0 +1,29 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+//@IncludeTags({"voucher_wait_for_fix"})
+@IncludeTags({"voucher-1ay"})
+public class Voucher1ayTest {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1bTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher1bTest.java
@@ -24,6 +24,6 @@ import org.junit.platform.suite.api.Suite;
 })
 @ExcludeTags({"wait_for_fix"})
 //@IncludeTags({"voucher_wait_for_fix"})
-@IncludeTags({"voucher-1"})
-public class Voucher1Test {
+@IncludeTags({"voucher-1b"})
+public class Voucher1bTest {
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher2Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher2Test.java
@@ -1,0 +1,29 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+//@IncludeTags({"voucher_wait_for_fix"})
+@IncludeTags({"voucher-2"})
+public class Voucher2Test {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher3Test.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/Voucher3Test.java
@@ -1,0 +1,29 @@
+package it.pagopa.pn.interop.cucumber;
+
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ConfigurationParameters;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameters({
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty"),
+        @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
+                "html:target/cucumber-report.html"),
+        @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
+        @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+})
+@ExcludeTags({"wait_for_fix"})
+//@IncludeTags({"voucher_wait_for_fix"})
+@IncludeTags({"voucher-3"})
+public class Voucher3Test {
+}

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/voucher/VoucherGenerationSteps.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/voucher/VoucherGenerationSteps.java
@@ -66,11 +66,10 @@ public class VoucherGenerationSteps {
                 .convertValue(response, VoucherResponse.class);
 
             assertSoftly(softly -> {
+                softly.assertThat(voucherResponse).isNotNull();
+                softly.assertThat(voucherResponse.getAccessToken()).isNotBlank();
+                softly.assertThat(voucherResponse.getExpiresIn()).isNotNull();
                 softly.assertThat(voucherResponse.getTokenType()).isEqualTo("Bearer");
-
-                /*NOTA 27/05/2025: controllo in più rispetto al test originale in TS*/
-                Map<String, Object> jwtClaims = decodeJwt(voucherResponse.getAccessToken());
-                softly.assertThat(jwtClaims.get("role").toString()).isEqualTo("m2m");
             });
         } catch (IllegalArgumentException e) {
             fail("La conversione dell'oggetto restituito in %s è fallita. E' possibile "

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-activate.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-activate.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-1
 Feature: Attivazione richiesta di fruizione
   Tutti gli utenti autorizzati di enti PA e GSP possono attivare una richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-archive.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-archive.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-1
 Feature: Archiviazione richiesta di fruizione
   Tutti gli utenti autorizzati possono archiviare una richiesta di fruizione in stato ACTIVE o SUSPENDED
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-clone.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-clone.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-1
 Feature: Clonazione di una richiesta di fruizione.
   Tutti gli utenti autorizzati possono clonare una richiesta di fruizione in stato REJECTED
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-consumers-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-consumers-listing.feature
@@ -1,4 +1,4 @@
-@agreement @resource_intensive
+@agreement-list @resource_intensive
 Feature: Listing fruitori con richieste di fruizione
   Tutti gli utenti autorizzati di enti PA e GSP possono ottenere la lista dei fruitori dei propri e-service
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-creation.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-creation.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-crud
 Feature: Creazione nuova richiesta di fruizione
   Tutti gli utenti autorizzati possono ottenere la lista dei fruitori dei propri e-service
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-delete.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-delete.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-crud
 Feature: Cancellazione richiesta di fruizione
   Tutti gli utenti autorizzati possono cancellare una richiesta di fruizione in stato DRAFT o MISSING_CERTIFIED_ATTRIBUTES
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-delete.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-delete.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-document
 Feature: Cancellazione di un documento allegato alla richiesta di fruizione
   Tutti gli utenti autorizzati possono cancellare un documento allegato alla richiesta di fruizione in stato DRAFT
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-read.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-document
 Feature: Lettura di un documento allegato alla richiesta di fruizione
   Tutti gli utenti autorizzati possono leggere un documento allegato alla richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-upload.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-document-upload.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-document
 Feature: Caricamento di un documento allegato alla richiesta di fruizione
   Tutti gli utenti autorizzati possono caricare un documento allegato alla richiesta di fruizione in stato DRAFT
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-download.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-download.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-1
 Feature: Download attestazione richiesta di fruizione sigillata
   Tutti gli utenti autorizzati possono scaricare l'attestazione di una richiesta di fruizione in stato ACTIVE, SUSPENDED o ARCHIVED.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-e-service-consumer-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-e-service-consumer-listing.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-list
 Feature: Listing e-service con richieste di fruizione attive lato fruitore
   Tutti gli utenti autorizzati possono ottenere la lista degli e-service per i quali hanno almeno una richiesta di fruizione attiva
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-e-service-producer-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-e-service-producer-listing.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-list
 Feature: Listing e-service con richieste di fruizione attive lato erogatore
   Tutti gli utenti autorizzati di enti PA e GSP possono ottenere la lista degli e-service con la quale hanno almeno una richiesta di fruizione attiva
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-listing.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-list
 Feature: Listing richieste di fruizione
   Tutti gli utenti autorizzati di enti PA, GSP e privati possono ottenere la lista delle richieste di fruizione
   NB: Gli e-service creati devono essere il minimo numero sufficiente per far passare il test, in caso contrario il sistema potrebbe sovraccaricarsi e non rispondere nei tempi attesi

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-producers-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-producers-listing.feature
@@ -1,4 +1,4 @@
-@agreement @resource_intensive
+@agreement-list @resource_intensive
 Feature: Listing erogatori con richieste di fruizione
   Tutti gli utenti autorizzati possono ottenere la lista degli erogatori degli e-service per cui hanno una richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-read.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-crud
 Feature: Lettura richiesta di fruizione
   Tutti gli utenti autorizzati possono leggere le richieste di fruizione che hanno creato
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-rejection.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-rejection.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-2
 Feature: Rifiuto di una richiesta di fruizione
   Tutti gli utenti autorizzati di enti PA e GSP possono rifiutare una richiesta di fruizione verso un proprio e-service
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-submit.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-submit.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-2
 Feature: Inoltro della richiesta di fruizione
 Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-suspension.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-suspension.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-2
 Feature: Sospensione richiesta di fruizione
   Tutti gli utenti autorizzati possono sospendere una richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-update.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-update.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-crud
 Feature: Aggiornamento di una richiesta di fruizione in bozza
   Tutti gli utenti autorizzati possono aggiornare una propria richiesta di fruizione in bozza con un messaggio
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-upgrade.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/agreement/agreement-upgrade.feature
@@ -1,4 +1,4 @@
-@agreement
+@agreement-2
 Feature: Upgrade di una richiesta di fruizione
   Tutti gli utenti autorizzati possono effettuare l'upgrade di una propria richiesta di fruizione
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-admin.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-admin.feature
@@ -1,3 +1,4 @@
+@client
 @client_admin
 Feature: Associazione di un admin ad un client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-create.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-create.feature
@@ -1,4 +1,5 @@
 @client
+@client-crud
 Feature: Creazione di un client
   Tutti gli admin possono creare un client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-delete.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-delete.feature
@@ -1,4 +1,5 @@
 @client
+@client-crud
 Feature: Cancellazione client
   Tutti gli utenti autorizzati possono cancellare il proprio client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-content-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-content-read.feature
@@ -1,5 +1,6 @@
 #Questo test è diverso da client-key-read. L'endpoint da testare qui è: /clients/{clientId}/encoded/keys/{keyId}
 @client
+@client-key
 Feature: Lettura di una chiave pubblica contenuta in un client
   Tutti gli utenti autenticati possono recuperare le informazioni di una chiave pubblica contenuta in un client 
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-delete.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-delete.feature
@@ -1,4 +1,5 @@
 @client
+@client-key
 Feature: Cancellazione delle chiavi di un client
   Tutti gli utenti autorizzati possono cancellare le chiavi del proprio client, security solo le proprie
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-read.feature
@@ -1,4 +1,5 @@
 @client
+@client-crud
 Feature: Lettura di una chiave pubblica contenuta in un client
   Tutti gli utenti autenticati possono recuperare le informazioni di una chiave pubblica contenuta in un client 
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-upload.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-key-upload.feature
@@ -1,4 +1,5 @@
 @client
+@client-key
 Feature: Caricamento di una chiave pubblica contenuta in un client
   Tutti gli utenti autorizzati o security possono caricare una chiave pubblica di tipo RSA lunghezza 2048
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-keys-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-keys-listing.feature
@@ -1,4 +1,5 @@
 @client
+@client-key
 Feature: Listing chiavi client
   Tutti gli utenti autorizzati, security o support possono leggere la lista delle chiavi di un client a cui sono associati
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-listing.feature
@@ -1,4 +1,5 @@
 @client
+@client-crud
 Feature: Listing client
   Tutti gli utenti autenticati possono leggere la lista dei client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-purpose-add.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-purpose-add.feature
@@ -1,4 +1,5 @@
 @client
+@client-purpose
 Feature: Associazione finalità al client
   Tutti gli utenti autenticati possono associare una finalità ad un client
   

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-purpose-remove.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-purpose-remove.feature
@@ -1,4 +1,5 @@
 @client
+@client-purpose
 Feature: Rimozione purpose dal client
   Tutti gli utenti autenticati possono disassociare una finalità da un client 
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-read.feature
@@ -1,4 +1,5 @@
 @client
+@client-crud
 Feature: Lettura client singolo
   Tutti gli utenti autenticati possono leggere un singolo client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-user-add.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-user-add.feature
@@ -1,4 +1,5 @@
 @client
+@client-user
 Feature: Aggiunta di un membro ad un client
   Tutti gli admin possono associare un membro ad un client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-user-remove.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-user-remove.feature
@@ -1,4 +1,5 @@
 @client
+@client-user
 Feature: Rimozione di un membro da un client
   Tutti gli admin possono rimuovere un membro da un client
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-users-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/authorization/client-users-listing.feature
@@ -1,4 +1,5 @@
 @client
+@client-user
 Feature: Listing utenti client
   Tutti gli utenti autorizzati o security possono leggere la lista dei membri di un client a cui sono associati
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-activation.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-activation.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-1
 Feature: Attivazione e riattivazione di una finalità
   Tutti gli utenti autorizzati possono attivare o riattivare una finalità
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-archive.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-archive.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-1
 Feature: Archiviazione di una finalità
   Tutti gli utenti autorizzati possono archiviare una propria finalità
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-clone.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-clone.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-1
 Feature: Clonazione di una finalità
   Tutti gli utenti autorizzati di enti fruitori possono clonare una propria finalità
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-creation-mode-deliver.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-creation-mode-deliver.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-creation
 Feature: Creazione finalità per e-service in erogazione diretta
   Tutti gli utenti autorizzati possono creare una nuova finalità per un e-service in erogazione diretta.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-creation-mode-receive.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-creation-mode-receive.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-creation
 Feature: Creazione finalità per e-service in erogazione inversa
   Tutti gli utenti autorizzati possono creare una nuova finalità per un e-service in erogazione inversa.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-delete.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-delete.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-1
 Feature: Cancellazione finalità
   Tutti gli admin possono cancellare una propria finalità in stato DRAFT o WAITING_FOR_APPROVAL.
   

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-listing-consumer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-listing-consumer.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-list
 Feature: Lista delle finalità lato fruitore
   Tutti gli utenti possono ottenere la lista delle finalità di cui sono fruitori
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-listing-producer.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-listing-producer.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-list
 Feature: Listing finalità lato erogatore
   Tutti gli utenti di enti PA e GSP possono ottenere la lista di finalità di cui sono erogatori.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-read.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-2
 Feature: Lettura singola finalità
   Tutti gli utenti possono leggere una finalità, l'analisi del rischio è disponibile solo per admin fruitori o erogatori di quella finalità.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-reject.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-reject.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-2
 Feature: Rifiuto di una versione di una finalità
   Tutti gli utenti autorizzati di enti erogatori possono rifiutare una nuova versione di una finalità
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-suspend.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-suspend.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-2
 Feature: Sospensione di una finalità
   Tutti gli utenti autorizzati possono sospendere una propria finalità
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-update-draft-mode-deliver.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-update-draft-mode-deliver.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-mode
 Feature: Aggiornamento bozza nuova finalità in erogazione diretta
   Tutti gli utenti autorizzati possono aggiornare una finalità in bozza per un e-service in erogazione diretta.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-update-draft-mode-receive.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-update-draft-mode-receive.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-mode
 Feature: Aggiornamento bozza nuova finalità in erogazione inversa
   Tutti gli utenti autorizzati possono aggiornare una finalità in bozza per un e-service in erogazione inversa.
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-version-create.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose/purpose-version-create.feature
@@ -1,4 +1,4 @@
-@purpose
+@purpose-version
 Feature: Creazione di una nuova versione di finalità
   Tutti gli utenti autorizzati di un ente fruitore possono richiedere un cambio di piano aggiornando le dailyCalls
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-assign-certified-attribute.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-assign-certified-attribute.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-assign
 Feature: Assegnazione di un attributo certificato ad un aderente
   Tutti gli utenti autorizzati degli enti certificatori possono assegnare un attributo certificato
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-assign-verified-attribute.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-assign-verified-attribute.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-assign
 Feature: Assegnazione di un attributo verificato ad un aderente
   Tutti gli utenti autorizzati di enti che possono erogare eservice possono assegnare un attributo verificato
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-certified-attributes-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-certified-attributes-listing.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-listing
 Feature: Listing attributi certificati posseduti da uno specifico aderente
   Tutti gli utenti autenticati possono leggere la lista degli attributi certificati posseduti da uno specifico aderente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-declared-attributes-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-declared-attributes-listing.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-listing
 Feature: Listing attributi dichiarati posseduti da uno specifico ente
   Tutti gli utenti autenticati possono leggere la lista degli attributi dichiarati posseduti da uno specifico ente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-e-service-consumers-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-e-service-consumers-listing.feature
@@ -1,4 +1,5 @@
 @tenant @PIN-5022
+@tenant-listing
 Feature: Listing e-service consumers
   Tutti gli utenti autenticati possono leggere la lista dei aderenti che sono iscritti ad almeno un e-service di cui sono erogatori
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-e-service-producers-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-e-service-producers-listing.feature
@@ -1,4 +1,5 @@
 @tenant @PIN-5022
+@tenant-listing
 Feature: Listing e-service producers
   Tutti gli utenti autenticati possono leggere la lista dei aderenti che erogano almeno un e-service
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-mail-upsert.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-mail-upsert.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-1
 Feature: Aggiunta o aggiornamento di una mail di contatto
   Tutti gli utenti autenticati possono aggiungere o aggiornare una mail di contatto
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-read.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-read.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-1
 Feature: Lettura di un singolo aderente
   Tutti gli utenti autenticati possono leggere un singolo aderente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-requester-certified-attributes-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-requester-certified-attributes-listing.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-listing
 Feature: Listing attributi certificati assegnati dall'ente certificatore
   Tutti gli utenti autorizzati di enti certificatori possono leggere la lista degli attributi certificati assegnati.
   Ai fini dei test solo PA2 e GSP2 sono certificatori, la quale qualifica non può essere assegnata durante la loro esecuzione.

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-certified-attribute.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-certified-attribute.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-revoke
 Feature: Revoca di un attributo certificato posseduto da uno specifico aderente
   Tutti gli utenti autorizzati degli enti certificatori possono revocare uno degli attributi certificati che hanno assegnato precedentemente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-declared-attribute.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-declared-attribute.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-revoke
 Feature: Revoca di un attributo dichiarato posseduto da uno specifico aderente
   Tutti gli utenti autorizzati degli enti erogatori possono revocare uno degli attributi dichiarati che si sono precedentemente assegnati
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-verified-attribute.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-revoke-verified-attribute.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-revoke
 Feature: Revoca di un attributo verificato posseduto da uno specifico aderente
   Tutti gli utenti autorizzati degli enti erogatori possono revocare uno degli attributi verificati che hanno assegnato precedentemente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-update-verified-expiration-date.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-update-verified-expiration-date.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-1
 Feature: Aggiornamento della data di scadenza di un attributo verificato ad un aderente
   Tutti gli utenti autorizzati di enti che possono erogare eservice possono aggiornare la data di scadenza di un proprio attributo verificato
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-verified-attributes-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenant-verified-attributes-listing.feature
@@ -1,4 +1,5 @@
 @tenant
+@tenant-listing
 Feature: Listing attributi verificati posseduti da uno specifico ente
   Tutti gli utenti autenticati possono leggere la lista degli attributi verificati posseduti da uno specifico ente
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenants-listing.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/tenant/tenants-listing.feature
@@ -1,4 +1,5 @@
 @tenants
+@tenants-listing
 Feature: Listing degli aderenti
   Tutti gli utenti autenticati possono leggere la lista dei aderenti
 

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-1
 Feature: Generazione del voucher sulle richieste di fruizione
 
 @voucher_generation_agreement1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
@@ -1,6 +1,7 @@
 @voucher-1a
 Feature: Generazione del voucher sulle richieste di fruizione
 
+@voucher-1ax
 @voucher_generation_agreement1
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione viene sospesa e poi riattivata dall’erogatore
     Given l'utente è un "admin" di "PA1"
@@ -16,6 +17,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement2
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione viene sospesa e poi riattivata dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -31,6 +33,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement3
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione viene sospesa dall’erogatore e dal fruitore, e poi riattivata sia dall’erogatore che dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -48,6 +51,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement4 @no-parallel
 Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e poi riottiene un attributo certificato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -66,6 +70,7 @@ Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e p
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement5
 Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e poi riottiene un attributo verificato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -86,6 +91,7 @@ Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e p
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement6 @no-parallel
 Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e poi riottiene un attributo dichiarato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -104,6 +110,7 @@ Scenario: La generazione del Voucher va a buon fine quando il fruitore perde e p
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement7
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione attiva subisce un upgrade verso una Versione dell’EService più recente, e l’upgrade viene completato direttamente
     Given l'utente è un "admin" di "PA1"
@@ -119,6 +126,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement8 @wait_for_fix @PIN-5405
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione attiva subisce un upgrade verso una Versione dell’EService più recente, e la richiesta rimane in attesa di approvazione
     Given l'utente è un "admin" di "PA1"
@@ -136,6 +144,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher 
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ax
 @voucher_generation_agreement9 @wait_for_fix @PIN-5405
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione attiva subisce un upgrade verso una Versione dell’EService più recente, e la richiesta passa in attesa di approvazione e poi approvata dall’erogatore
     Given l'utente è un "admin" di "PA1"
@@ -156,6 +165,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ay
 @voucher_generation_agreement10 @wait_for_fix @PIN-5405
 Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruizione attiva subisce un upgrade verso una Versione dell’EService più recente, e la richiesta passa in attesa di approvazione e poi rifiutata dall’erogatore
     Given l'utente è un "admin" di "PA1"
@@ -174,6 +184,7 @@ Scenario: La generazione del Voucher va a buon fine quando la richiesta di fruiz
     When l'utente richiede la generazione del voucher
     Then si ottiene la corretta generazione del voucher
 
+@voucher-1ay
 @voucher_generation_agreement11
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione è sospesa dall’erogatore
     Given l'utente è un "admin" di "PA1"
@@ -188,6 +199,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione �
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement12
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione è sospesa dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -202,6 +214,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione �
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement13
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione è sospesa sia dall’erogatore che dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -217,6 +230,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione �
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement14
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione è sospesa sia dall’erogatore che dal fruitore, e poi riattivata dall’erogatore
     Given l'utente è un "admin" di "PA1"
@@ -233,6 +247,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione �
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement15
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione è sospesa sia dall’erogatore che dal fruitore, e poi riattivata dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -249,6 +264,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione �
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement16 @no-parallel
 Scenario: La generazione del Voucher fallisce quando il fruitore perde un attributo certificato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -265,6 +281,7 @@ Scenario: La generazione del Voucher fallisce quando il fruitore perde un attrib
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement17 @no-parallel
 Scenario: La generazione del Voucher fallisce quando il fruitore perde un attributo verificato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -283,6 +300,7 @@ Scenario: La generazione del Voucher fallisce quando il fruitore perde un attrib
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement18 @no-parallel
 Scenario: La generazione del Voucher fallisce quando il fruitore perde un attributo dichiarato necessario all’utilizzo dell’EService
     Given l'utente è un "admin" di "PA1"
@@ -299,6 +317,7 @@ Scenario: La generazione del Voucher fallisce quando il fruitore perde un attrib
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement19
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione viene archiviata dal fruitore
     Given l'utente è un "admin" di "PA1"
@@ -313,6 +332,7 @@ Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione v
     When l'utente richiede la generazione del voucher
     Then la richiesta di generazione del Voucher non va a buon fine
 
+@voucher-1ay
 @voucher_generation_agreement20
 Scenario: La generazione del Voucher fallisce quando la richiesta di fruizione sospesa subisce un upgrade verso una Versione dell’EService più recente, e l’upgrade viene completato direttamente
     Given l'utente è un "admin" di "PA1"

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-agreement.feature
@@ -1,4 +1,4 @@
-@voucher-1
+@voucher-1a
 Feature: Generazione del voucher sulle richieste di fruizione
 
 @voucher_generation_agreement1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-client-and-keys.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-client-and-keys.feature
@@ -1,4 +1,4 @@
-@voucher-1
+@voucher-1b
 Feature: Generazione del voucher sulla creazione del client e sul caricamento della chiave
 
 @voucher_generation_client_and_keys1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-client-and-keys.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-client-and-keys.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-1
 Feature: Generazione del voucher sulla creazione del client e sul caricamento della chiave
 
 @voucher_generation_client_and_keys1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-eservice.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-eservice.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-2
 Feature: Generazione del voucher richiesta da un Ente
 
   @voucher_generation_eservice1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-m2m.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-m2m.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-2
 Feature: Generazione del voucher m2m richiesta da un Ente
 
   @voucher_generation_m2m1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-params-validation.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-params-validation.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-3
 Feature: Generazione del voucher richiesta da un Ente
 
   @voucher_generation_params_validation1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-purpose.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation-purpose.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-3
 Feature: Generazione del voucher richiesta da un Ente
 
   @voucher_generation_purpose1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation.feature
@@ -1,4 +1,4 @@
-@voucher-1
+@voucher-1b
 Feature: Generazione del voucher richiesta da un Ente
 
   @voucher_generation1

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/voucher/voucher-generation.feature
@@ -1,4 +1,4 @@
-@voucher
+@voucher-1
 Feature: Generazione del voucher richiesta da un Ente
 
   @voucher_generation1


### PR DESCRIPTION
[QA-8148](https://pagopa.atlassian.net/browse/QA-8148): una problematica su Github che impedisce il download di file di log relativamente grandi ha comportato lo splitting delle classi-runner esistenti, allo scopo di produrre log più circoscritti come soluzione a breve termine.

[QA-8148]: https://pagopa.atlassian.net/browse/QA-8148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ