### PR TITLE
QA-8277: added check to verify that DATAPRIVACY_SERCQ is not available during TOS submission

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
@@ -1027,6 +1027,7 @@ public class RicezioneNotificheWebSteps {
             Assertions.assertNotNull(data.getConsentType());
             Assertions.assertEquals(ConsentType.TOS_SERCQ, data.getConsentType());
             Assertions.assertEquals(data.getAccepted(), tosStatus.equalsIgnoreCase("positiva"));
+            Assertions.assertNotEquals(ConsentType.DATAPRIVACY_SERCQ, data.getConsentType());
         });
     }
 


### PR DESCRIPTION
Added check to verify that DATAPRIVACY_SERCQ is not available if it is not present as a query parameter in the GET request