### PR TITLE
QA 8488

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
@@ -400,6 +400,30 @@ public abstract class B2bUtils {
     }
 
     /**
+     * Verifica se un oggetto "expected" ha tutti i campi null, nel qual caso verifica semplicemente che "actual" != null
+     *
+     * @return true se tutti i campi sono null
+     */
+    public static boolean expectedIsSimplyNotNullValue(Object expected) {
+        Class<?> clazz = expected.getClass();
+        List<Field> nonStaticFields = Arrays.stream(clazz.getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers())).toList();
+        try {
+            for (Field expectedField : nonStaticFields) {
+                expectedField.setAccessible(true);
+                Object expectedValue = expectedField.get(expected);
+                if (expectedValue != null) {
+                    return false;
+                }
+            }
+        } catch (IllegalAccessException e) {
+            assertThat(true)
+                    .as("Eccezione imprevista in fase di verifica se l'expected è NOT NULL tramite reflection " + e.getMessage())
+                    .isFalse();
+        }
+        return true;
+    }
+
+    /**
      * Confronta due oggetti qualsiasi, valutando l'uguaglianza solo per i field != null specificati nell'expected
      * (NOTA: eventuali campi statici sono esclusi da questa verifica)
      */

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
@@ -400,11 +400,12 @@ public abstract class B2bUtils {
     }
 
     /**
-     * Verifica se un oggetto "expected" ha tutti i campi null, nel qual caso verifica semplicemente che "actual" != null
+     * Verifica se un oggetto "expected" ha tutti i campi null.
+     * Usato in fase di confronto expected/actual: quando expected ha tutti i campi null si procede a verificare che actual != null
      *
-     * @return true se tutti i campi sono null
+     * @return true se tutti i campi dell'oggetto sono null
      */
-    public static boolean expectedIsSimplyNotNullValue(Object expected) {
+    public static boolean objectHasAllFieldsNull(Object expected) {
         Class<?> clazz = expected.getClass();
         List<Field> nonStaticFields = Arrays.stream(clazz.getDeclaredFields()).filter(field -> !Modifier.isStatic(field.getModifiers())).toList();
         try {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV1.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV1.java
@@ -164,7 +164,11 @@ public class DataTestV1 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV1.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV1.java
@@ -164,7 +164,7 @@ public class DataTestV1 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV20.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV20.java
@@ -164,7 +164,7 @@ public class DataTestV20 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV20.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV20.java
@@ -164,7 +164,11 @@ public class DataTestV20 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV21.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV21.java
@@ -164,7 +164,7 @@ public class DataTestV21 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV21.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV21.java
@@ -164,7 +164,11 @@ public class DataTestV21 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV23.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV23.java
@@ -164,7 +164,11 @@ public class DataTestV23 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV23.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV23.java
@@ -164,7 +164,7 @@ public class DataTestV23 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV24.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV24.java
@@ -164,7 +164,7 @@ public class DataTestV24 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV24.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV24.java
@@ -164,7 +164,11 @@ public class DataTestV24 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV25.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV25.java
@@ -177,7 +177,7 @@ public class DataTestV25 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                        if (B2bUtils.objectHasAllFieldsNull(expected.getPhysicalAddress())) {
                             assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
                         } else {
                             B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());

--- a/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV25.java
+++ b/src/test/java/it/pagopa/pn/cucumber/utils/datatestVersions/DataTestV25.java
@@ -177,7 +177,11 @@ public class DataTestV25 extends AbstractDataTest {
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getPhysicalAddress() != null) {
-                        B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        if (B2bUtils.expectedIsSimplyNotNullValue(expected.getPhysicalAddress())) {
+                            assertThat(actual.getPhysicalAddress()).as(error + EQUALITY_PHYSICAL_ADDRESS).isNotNull();
+                        } else {
+                            B2bUtils.compareActualAndExpected(error + EQUALITY_PHYSICAL_ADDRESS, actual.getPhysicalAddress(), expected.getPhysicalAddress());
+                        }
                     }
                     //ignorare Sonar che dice che questa condizione è sempre true (in quanto il campo è annotato con @NotNull), non è vero
                     if (expected.getResponseStatus() != null && expected.getResponseStatus().getValue() != null) {

--- a/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPFAnalogicoNR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPFAnalogicoNR.feature
@@ -36,17 +36,16 @@ Feature: avanzamento b2b notifica PF analogico con chiamata a National Registry 
 
   @workflowAnalogico @mockNR
   Scenario: [B2B_TIMELINE_ANALOG_76]  Invio notifica mono destinatario a PF analogica con restituzione indirizzo fisico italiano da ANPR - Mock (successo al secondo tentativo)
-#    Given viene generata una nuova notifica
-#      | subject               | notifica analogica con cucumber |
-#      | senderDenomination    | Comune di palermo               |
-#      | physicalCommunication | AR_REGISTERED_LETTER            |
-#    And destinatario
-#      | denomination            | Test AR Fail 2           |
-#      | taxId                   | FRMTTR76M06B715E         |
-#      | digitalDomicile         | NULL                     |
-#      | physicalAddress_address | Via@FAIL-Irreperibile_AR |
-#    When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
-    Given imposto lo iun di SharedSteps a "NEVZ-HMJQ-PWXY-202507-E-1" e la pa a "Comune_Multi"
+    Given viene generata una nuova notifica
+      | subject               | notifica analogica con cucumber |
+      | senderDenomination    | Comune di palermo               |
+      | physicalCommunication | AR_REGISTERED_LETTER            |
+    And destinatario
+      | denomination            | Test AR Fail 2           |
+      | taxId                   | FRMTTR76M06B715E         |
+      | digitalDomicile         | NULL                     |
+      | physicalAddress_address | Via@FAIL-Irreperibile_AR |
+    When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     And viene verificato che l'elemento di timeline "SEND_ANALOG_FEEDBACK" esista
       | loadTimeline            | true     |
       | details                 | NOT_NULL |

--- a/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPFAnalogicoNR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/nationalRegistries/AvanzamentoNotificheB2bPFAnalogicoNR.feature
@@ -35,17 +35,32 @@ Feature: avanzamento b2b notifica PF analogico con chiamata a National Registry 
 
 
   @workflowAnalogico @mockNR
-  Scenario: [B2B_TIMELINE_ANALOG_76]  Invio notifica  mono destinatario a PF analogica  con restituzione indirizzo fisico italiano da ANPR - Mock
-    Given viene generata una nuova notifica
-      | subject               | notifica analogica con cucumber |
-      | senderDenomination    | Comune di palermo               |
-      | physicalCommunication | AR_REGISTERED_LETTER            |
-    And destinatario
-      | denomination            | Test AR Fail 2           |
-      | taxId                   | FRMTTR76M06B715E         |
-      | digitalDomicile         | NULL                     |
-      | physicalAddress_address | Via@FAIL-Irreperibile_AR |
-    When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
+  Scenario: [B2B_TIMELINE_ANALOG_76]  Invio notifica mono destinatario a PF analogica con restituzione indirizzo fisico italiano da ANPR - Mock (successo al secondo tentativo)
+#    Given viene generata una nuova notifica
+#      | subject               | notifica analogica con cucumber |
+#      | senderDenomination    | Comune di palermo               |
+#      | physicalCommunication | AR_REGISTERED_LETTER            |
+#    And destinatario
+#      | denomination            | Test AR Fail 2           |
+#      | taxId                   | FRMTTR76M06B715E         |
+#      | digitalDomicile         | NULL                     |
+#      | physicalAddress_address | Via@FAIL-Irreperibile_AR |
+#    When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
+    Given imposto lo iun di SharedSteps a "NEVZ-HMJQ-PWXY-202507-E-1" e la pa a "Comune_Multi"
+    And viene verificato che l'elemento di timeline "SEND_ANALOG_FEEDBACK" esista
+      | loadTimeline            | true     |
+      | details                 | NOT_NULL |
+      | details_recIndex        | 0        |
+      | details_sentAttemptMade | 0        |
+      | details_responseStatus  | KO       |
+      | details_physicalAddress | {}       |
+    And viene verificato che l'elemento di timeline "SEND_ANALOG_FEEDBACK" esista
+      | loadTimeline            | true     |
+      | details                 | NOT_NULL |
+      | details_recIndex        | 0        |
+      | details_sentAttemptMade | 1        |
+      | details_responseStatus  | OK       |
+      | details_physicalAddress | {}       |
     Then vengono letti gli eventi fino all'elemento di timeline della notifica "ANALOG_SUCCESS_WORKFLOW"
     And vengono letti gli eventi fino allo stato della notifica "DELIVERED" dalla PA "Comune_Multi"
 


### PR DESCRIPTION
Creazione di una nuovo metodo ad hoc per verificare che un campo passato nel dataTable sia != null (Serve ad irrobustire alcuni controlli che non ci avevano permesso di individuare un bug)