### PR TITLE
Fix municipality details

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
@@ -448,11 +448,13 @@ public abstract class B2bUtils {
                     Object actualValue = actualField.get(actual);
                     if (expectedValue != null) {
                         //TODO: aggiunto controllo isEqualToIgnoringCase per i campi stringa dell PhysicalAddress (escluso municipalityDetails) causa consolidatore che fa fallire i test
-                        if (expectedField.getType().equals(String.class) && !fieldName.equals("municipalityDetails")) {
-                            assertThat(actualValue).as(error + fieldName + " non dev'essere null").isNotNull();
-                            String stringActual = (String) actualValue;
-                            String stringExpected = (String) expectedValue;
-                            assertThat(stringActual).as(error + fieldName + " non coincide col valore atteso").isEqualToIgnoringCase(stringExpected);
+                        if (expectedField.getType().equals(String.class)) {
+                            if (!fieldName.equals("municipalityDetails")) {
+                                assertThat(actualValue).as(error + fieldName + " non dev'essere null").isNotNull();
+                                String stringActual = (String) actualValue;
+                                String stringExpected = (String) expectedValue;
+                                assertThat(stringActual).as(error + fieldName + " non coincide col valore atteso").isEqualToIgnoringCase(stringExpected);
+                            }
                         } else {
                             assertThat(actualValue).as(error + fieldName + " non coincide col valore atteso").isEqualTo(expectedValue);
                         }


### PR DESCRIPTION
Fix municipality details (splittato il primo if in due if distinti, per evitare che la casistica di municipalityDetails ricadesse nell'else, cosa che porterebbe al fail per i soliti motivi di COSENZA COSENZA)