### PR TITLE
FixPaperTrackerSequences

### DIFF
--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/b2b/giacenzaAttoGiudiziario890/GestioneGiacenzaAttoGiudiziario890.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/b2b/giacenzaAttoGiudiziario890/GestioneGiacenzaAttoGiudiziario890.feature
@@ -778,11 +778,6 @@ Feature: avanzamento notifiche b2b con workflow cartaceo gestione giacenza atto 
       | details_deliveryDetailCode | RECAG006B                 |
       | details_sentAttemptMade    | 0                         |
       | details_attachments        | [{"documentType": "23L"}] |
-    And viene verificato che l'elemento di timeline "SEND_ANALOG_PROGRESS" esista
-      | details                    | NOT_NULL  |
-      | details_recIndex           | 0         |
-      | details_deliveryDetailCode | RECAG006C |
-      | details_sentAttemptMade    | 0         |
     And viene verificato che l'elemento di timeline "SEND_ANALOG_FEEDBACK" esista
       | details                    | NOT_NULL                                                                                                                                                                                                                    |
       | details_recIndex           | 0                                                                                                                                                                                                                           |
@@ -838,23 +833,9 @@ Feature: avanzamento notifiche b2b con workflow cartaceo gestione giacenza atto 
       | details_deliveryDetailCode | RECAG007B                   |
       | details_sentAttemptMade    | 0                           |
       | details_attachments        | [{"documentType": "Plico"}] |
-    And viene verificato che l'elemento di timeline "SEND_ANALOG_FEEDBACK" esista
-      | details                    | NOT_NULL                                                                                                                                                                                                                 |
-      | details_recIndex           | 0                                                                                                                                                                                                                        |
-      | details_deliveryDetailCode | PNAG012                                                                                                                                                                                                                  |
-      | details_sentAttemptMade    | 0                                                                                                                                                                                                                        |
-      | details_physicalAddress    | {"at": "Presso", "address": "@FAIL-GIACENZA-GT10_890_NO_RECAG012", "addressDetails": "SCALA B", "zip": "87100", "municipality": "COSENZA", "municipalityDetails": "COSENZA", "province": "CS", "foreignState": "ITALIA"} |
-      | details_responseStatus     | OK                                                                                                                                                                                                                       |
-    # TODO come fa a essere OK e non KO il risultato atteso, se è una sequenza di tipo fail?
-    And viene verificato che l'elemento di timeline "SEND_ANALOG_PROGRESS" esista
-      | details                    | NOT_NULL  |
-      | details_recIndex           | 0         |
-      | details_deliveryDetailCode | RECAG007C |
-      | details_sentAttemptMade    | 0         |
     And viene verificato che l'elemento di timeline "ANALOG_SUCCESS_WORKFLOW" esista
       | NULL | NULL |
     #"@sequence.5s-CON080.5s-CON020[DOC:7ZIP;PAGES:3].5s-RECAG010.5s-RECAG011A.60s-RECAG011B[DOC:ARCAD;DOC:23L].60s-RECAG007A.5s-RECAG007B[DOC:Plico].5s-RECAG007C"
-    #PNAG012 come evento di feedback con data: RECAG011A + refinementDuration (1 minuto in DEV)
 
  # SEND_ANALOG_FEEDBACK------------------
   #deliveryDetailCode: RECRN002C

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/giacenza/giacenzaAR/AvanzamentoNotifichePFAnalogicoGiacenzaAR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/giacenza/giacenzaAR/AvanzamentoNotifichePFAnalogicoGiacenzaAR.feature
@@ -301,4 +301,4 @@ Feature: avanzamento notifiche b2b con workflow cartaceo giacenza AR
       | physicalAddress_address | Via@FAIL-CompiutaGiacenza_AR |
     When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     Then vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_ANALOG_PROGRESS" con deliveryDetailCode "CON080"
-    And vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_ANALOG_FEEDBACK" con deliveryDetailCode "RECRN002C"
+    And vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_ANALOG_FEEDBACK" con deliveryDetailCode "RECRN005C"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/giacenza/giacenzaAR/AvanzamentoNotifichePFAnalogicoGiacenzaAR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/giacenza/giacenzaAR/AvanzamentoNotifichePFAnalogicoGiacenzaAR.feature
@@ -297,9 +297,8 @@ Feature: avanzamento notifiche b2b con workflow cartaceo giacenza AR
       | senderDenomination    | Comune di palermo               |
       | physicalCommunication | AR_REGISTERED_LETTER            |
     And destinatario Mario Gherkin e:
-      | digitalDomicile         | NULL                              |
-      | physicalAddress_address | Via@FAIL-CompiutaGiacenza-gt10_AR |
+      | digitalDomicile         | NULL                         |
+      | physicalAddress_address | Via@FAIL-CompiutaGiacenza_AR |
     When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     Then vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_ANALOG_PROGRESS" con deliveryDetailCode "CON080"
     And vengono letti gli eventi fino all'elemento di timeline della notifica "SEND_ANALOG_FEEDBACK" con deliveryDetailCode "RECRN002C"
-    #"@sequence.MANCANTE

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflowAr/AvanzamentoNotificheEventiSuccessivi.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflowAr/AvanzamentoNotificheEventiSuccessivi.feature
@@ -16,11 +16,10 @@ Feature: Gestione Feedback Analogici Duplicati
   @workflowAnalogico
   Scenario: [B2B_FEEDBACK_ANALOG_2] Invio notifica Analogica - Caso avanzamento spedizione e ricezione eventi di PROGRESS
     Given viene generata una nuova notifica
-      | subject               | invio notifica con cucumber |
-      | senderDenomination    | Comune di milano            |
-      | physicalCommunication | REGISTERED_LETTER_890       |
+      | subject            | invio notifica con cucumber |
+      | senderDenomination | Comune di milano            |
     And destinatario Gherkin Analogic e:
-      | digitalDomicile         | NULL            |
+      | digitalDomicile_address | test@fail.it    |
       | physicalAddress_address | Via@OK_START_RS |
     When la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     Then vengono letti gli eventi fino allo stato della notifica "DELIVERING"

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflowAr/AvanzamentoNotifichePFAnalogicoAR.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/workflowAnalogico/workflowAr/AvanzamentoNotifichePFAnalogicoAR.feature
@@ -149,7 +149,6 @@ Feature: avanzamento notifiche b2b con workflow cartaceo AR
       | details_recIndex           | 0        |
       | details_deliveryDetailCode | CON020   |
       | details_sentAttemptMade    | 1        |
-      | progressIndex              | 3        |
     And viene verificato che l'elemento di timeline "SEND_ANALOG_PROGRESS" esista
       | details                    | NOT_NULL  |
       | details_recIndex           | 0         |


### PR DESCRIPTION
fix: edit di alcuni scenari in seguito all'attivazione di PaperTracker in modalità run (sequences obsolete corrette, elementi attesi che ora non arrivano più rimossi, indici del timelineElementId variabili esclusi dai check)