### PR TITLE
QA-12059: aggiornamento NRT picchi

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/Delayer1Test.java
+++ b/src/test/java/it/pagopa/pn/cucumber/Delayer1Test.java
@@ -1,0 +1,27 @@
+package it.pagopa.pn.cucumber;
+
+import org.junit.platform.suite.api.*;
+
+import static io.cucumber.junit.platform.engine.Constants.*;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("it/pagopa/pn/cucumber")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+@ConfigurationParameter(
+        key = PLUGIN_PROPERTY_NAME,
+        value = "json:target/cucumber-report.json,html:target/cucumber-report.html"
+)
+@ConfigurationParameter(
+        key = GLUE_PROPERTY_NAME,
+        value = "it.pagopa.pn.cucumber.steps"
+)
+// Imposta esecuzione sequenziale
+@ConfigurationParameter(
+        key = EXECUTION_MODE_FEATURE_PROPERTY_NAME,
+        value = "same_thread"
+)
+@ExcludeTags({"ignore"})
+@IncludeTags({"delayer1"})
+public class Delayer1Test {
+}

--- a/src/test/java/it/pagopa/pn/cucumber/Delayer3Test.java
+++ b/src/test/java/it/pagopa/pn/cucumber/Delayer3Test.java
@@ -22,6 +22,6 @@ import static io.cucumber.junit.platform.engine.Constants.*;
         value = "same_thread"
 )
 @ExcludeTags({"ignore"})
-@IncludeTags({"delayer3", "delayer4", "delayer5"})
+@IncludeTags({"delayer3"})
 public class Delayer3Test {
 }

--- a/src/test/java/it/pagopa/pn/cucumber/Delayer3Test.java
+++ b/src/test/java/it/pagopa/pn/cucumber/Delayer3Test.java
@@ -22,6 +22,6 @@ import static io.cucumber.junit.platform.engine.Constants.*;
         value = "same_thread"
 )
 @ExcludeTags({"ignore"})
-@IncludeTags({"delayer3"})
+@IncludeTags({"delayer3", "delayer4", "delayer5"})
 public class Delayer3Test {
 }

--- a/src/test/java/it/pagopa/pn/cucumber/steps/delayer/DelayerSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/delayer/DelayerSteps.java
@@ -263,13 +263,15 @@ public class DelayerSteps {
         Assertions.assertThat(tupla).isNotNull();
         boolean hasDeliveryInEvaluatePrint = !context.getExpectedByWorkflowStep(EVALUATE_PRINT_CAPACITY).isEmpty();
 
-        Assertions.assertThat(tupla.getDailyExecutionNumber())
-                .as(hasDeliveryInEvaluatePrint ? "DailyExecutionNumber deve essere uguale allo STANDARD_DAILY_EXECUTIONS" : "DailyExecutionNumber deve essere uguale a 0")
-                .isEqualTo(hasDeliveryInEvaluatePrint ? DelayerContext.STANDARD_DAILY_EXECUTIONS : 0);
+        if (hasDeliveryInEvaluatePrint) {
+            Assertions.assertThat(tupla.getDailyExecutionNumber())
+                    .as("DailyExecutionNumber deve essere uguale allo STANDARD_DAILY_EXECUTIONS")
+                    .isEqualTo(DelayerContext.STANDARD_DAILY_EXECUTIONS);
 
-        Assertions.assertThat(tupla.getDailyExecutionCounter())
-                .as("DailyExecutionCounter deve essere uguale a quello calcolato internamente")
-                .isEqualTo(context.currentStepFunction2ExecutionIndex);
+            Assertions.assertThat(tupla.getDailyExecutionCounter())
+                    .as("DailyExecutionCounter deve essere uguale a quello calcolato internamente")
+                    .isEqualTo(context.currentStepFunction2ExecutionIndex);
+        }
     }
 
     @When("vengono avviate le {int} esecuzioni della step function DelayerToPaperChannelStateMachine")


### PR DESCRIPTION
**Contesto**
A seguito di un bugfixing per la feature di PICCHI si è reso necessario l'aggiornamento degli NRT, dato che il contatore delle daily executions non viene più popolato a 0 se non ci sono più spedizioni ma invece non viene più passato.

**Impatto**
Aggiornamento dell'asserzione relativa al contatore delle daily executions