### PR TITLE
DelegheTemporanea update

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/DelegheTemporaneeSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/DelegheTemporaneeSteps.java
@@ -102,7 +102,6 @@ public class DelegheTemporaneeSteps {
             case "CX TAX ID E LOLLIPOP USER ID NON COINCIDENTI" -> lollipopUserId = Costanti.GALILEO_GALILEI_TAX_ID;
         }
 
-        mandateCreationResponse = null;
         try {
             mandateCreationResponse = mandateAppIoClient.createIOMandate(
                     taxId, null, null, null, null,

--- a/src/test/resources/it/pagopa/pn/cucumber/DelegheTemporanee.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/DelegheTemporanee.feature
@@ -113,7 +113,7 @@ Feature: Deleghe Temporanee 15755
 
   #7
   @delegheTemporanee
-  Scenario: [MANDATE_TEMP_CREATION_FAILED_DELEGA_ALREADY_EXISTENT] Creazione senza successo di una delega temporanea (delega già presente per coppia IUN-taxId)
+  Scenario: [MANDATE_TEMP_CREATION_FAILED_DELEGA_ALREADY_EXISTENT] Creazione senza successo di una delega temporanea (delega già presente per coppia IUN-taxId); Viene fatta dunque scadere, si crea una nuova delega e la si accetta
     Given viene generata una nuova notifica
       | subject            | invio notifica delega temporanea |
       | senderDenomination | comune di Palermo                |
@@ -123,6 +123,14 @@ Feature: Deleghe Temporanee 15755
     And la delega temporanea è stata correttamente creata
     When Mario Gherkin viene temporaneamente delegato da "Mario Cucumber" passando "DATI VALIDI"
     Then l'operazione restituisce codice 409
+    When la delega viene fatta scadere
+    And la delega temporanea di Mario Cucumber viene accettata da Mario Gherkin passando "DATI VALIDI"
+    Then l'operazione restituisce codice 404
+    When Mario Gherkin viene temporaneamente delegato da "Mario Cucumber" passando "DATI_VALIDI"
+    And la delega temporanea è stata correttamente creata
+    And la delega temporanea di Mario Cucumber viene accettata da Mario Gherkin passando "DATI VALIDI"
+    And l'operazione non ha prodotto alcun errore
+    Then la notifica può essere correttamente letta da "Mario Gherkin" con delega
 
   #8
   @delegheTemporanee


### PR DESCRIPTION
fix: edit dello scenario MANDATE_TEMP_CREATION_FAILED_DELEGA_ALREADY_EXISTENT in modo da verificare contemporaneamente:

1) fail creazione delega a fronte di una già esistente 
2) successo creazione di una seconda delega (stessa notifica, stesso delegato) quando quella creata in precedenza scade

Vedi ticket QA12617 e QA12578