### PR TITLE
QA-12314 fix: patch PURPOSE_TEMPLATE_GET_BY_ID

### DIFF
--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/purposetemplate/PurposeTemplateSteps.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/purposetemplate/PurposeTemplateSteps.java
@@ -269,6 +269,13 @@ public class PurposeTemplateSteps {
         getPurposeTemplateById(ptId, exists);
     }
 
+    @When("si effettua la get del purpose template")
+    public void getPurposeTemplate() {
+        boolean exists = createdPurposeTemplate.getId() != null;
+        UUID ptId = exists ? createdPurposeTemplate.getId() : UUID.randomUUID();
+        httpCallExecutor.performCall(() -> purposeTemplateClient.getPurposeTemplate(ptId));
+    }
+
     @When("si effettua la get by creator di tutti i purpose template in stato {string}")
     public void getAllPurposeTemplatesByCreator(String status) {
         List<PurposeTemplateState> state;

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose-template/purpose-template-get-and-create.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/purpose-template/purpose-template-get-and-create.feature
@@ -101,8 +101,14 @@ Feature: finalità agevolata, purpose template GET
       | admin    | 200        |
       | api      | 200        |
       | support  | 200        |
-      # gli operatori security non possono fare la getById dei purposeTemplate in DRAFT
-      | security | 403        |
+
+  @purposeTemplate @purposeTemplateGet
+  Scenario: [PURPOSE_TEMPLATE_GET_BY_ID_B] Recupero di una finalità agevolata (OK)
+    Given l'utente è un "admin" di "PA1"
+    And viene creato un nuovo purpose template
+    When l'utente è un "security" di "PA1"
+    And si effettua la get del purpose template
+    Then si ottiene lo status code 404
 
   #9(KO)
   @purposeTemplate @purposeTemplateGet


### PR DESCRIPTION
Si in ottemperanza a https://pagopa.atlassian.net/browse/PIN-9150?focusedCommentId=291552 si modifica lo stato atteso per ruolo security, separando i casi di test