### PR TITLE
FIX PnAppIOB2bExternalClientImpl e suite di DelegheTemporanee

### DIFF
--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnAppIOB2bExternalClientImpl.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/impl/PnAppIOB2bExternalClientImpl.java
@@ -38,41 +38,41 @@ public class PnAppIOB2bExternalClientImpl implements IPnAppIOB2bClient {
     public PnAppIOB2bExternalClientImpl(RestTemplate restTemplate,
                                         @Value("${pn.appio.externa.base-url}") String devBasePath,
                                         @Value("${pn.external.appio.api-key}") String devApiKey) {
-        this.appIoPnDocumentsApi = new AppIoPnDocumentsApi( newApiClient( restTemplate, devBasePath, devApiKey) );
-        this.appIoPnNotificationApi = new AppIoPnNotificationApi( newApiClient( restTemplate, devBasePath, devApiKey) );
-        this.appIoPnPaymentsApi = new AppIoPnPaymentsApi( newApiClient( restTemplate, devBasePath, devApiKey) );
+        this.appIoPnDocumentsApi = new AppIoPnDocumentsApi(newApiClient(restTemplate, devBasePath, devApiKey));
+        this.appIoPnNotificationApi = new AppIoPnNotificationApi(newApiClient(restTemplate, devBasePath, devApiKey));
+        this.appIoPnPaymentsApi = new AppIoPnPaymentsApi(newApiClient(restTemplate, devBasePath, devApiKey));
     }
 
-    private static ApiClient newApiClient(RestTemplate restTemplate, String basePath, String apikey ) {
-        ApiClient newApiClient = new ApiClient( restTemplate );
-        newApiClient.addDefaultHeader("Accept", "application/io+json" );
-        newApiClient.setBasePath( basePath );
-        newApiClient.addDefaultHeader("x-api-key", apikey );
+    private static ApiClient newApiClient(RestTemplate restTemplate, String basePath, String apikey) {
+        ApiClient newApiClient = new ApiClient(restTemplate);
+        newApiClient.addDefaultHeader("Accept", "application/io+json");
+        newApiClient.setBasePath(basePath);
+        newApiClient.addDefaultHeader("x-api-key", apikey);
         return newApiClient;
     }
 
     public NotificationAttachmentDownloadMetadataResponse getSentNotificationDocument(String iun, Integer docIdx, String xPagopaCxTaxid, UUID mandate) throws RestClientException {
-        return this.appIoPnDocumentsApi.getReceivedNotificationDocument(iun, docIdx, xPagopaCxTaxid, mandate,null, null, null,null,null,null,xPagopaCxTaxid,null,null,null);
+        return this.appIoPnDocumentsApi.getReceivedNotificationDocument(iun, docIdx, xPagopaCxTaxid, mandate, null, null, "PublicKey", null, null, "AuthJwt", xPagopaCxTaxid, null, null, null);
     }
 
     public ThirdPartyMessage getReceivedNotification(String iun, String xPagopaCxTaxid, UUID mandateId) throws RestClientException {
-        return this.appIoPnNotificationApi.getReceivedNotification(iun, xPagopaCxTaxid, mandateId, null,null, null, null,null,null,xPagopaCxTaxid,null,null, null);
+        return this.appIoPnNotificationApi.getReceivedNotification(iun, xPagopaCxTaxid, mandateId, null, null, "PublicKey", null, null, "AuthJwt", xPagopaCxTaxid, null, null, null);
     }
 
     public ThirdPartyMessage getReceivedNotification(String iun, String xPagopaCxTaxid, UUID mandateId, String xPagopaPnIoSrc) throws RestClientException {
-        return this.appIoPnNotificationApi.getReceivedNotification(iun, xPagopaCxTaxid, mandateId, null,null, null, null,null,null,null,null,null, xPagopaPnIoSrc);
+        return this.appIoPnNotificationApi.getReceivedNotification(iun, xPagopaCxTaxid, mandateId, null, null, "PublicKey", null, null, "AuthJwt", null, null, null, xPagopaPnIoSrc);
     }
 
     public NotificationAttachmentDownloadMetadataResponse getReceivedNotificationAttachment(String iun, String attachmentName, String xPagopaCxTaxid, Integer attachmentIdx, UUID mandateId) throws RestClientException {
-        return this.appIoPnPaymentsApi.getReceivedNotificationAttachment(iun, attachmentName, xPagopaCxTaxid, attachmentIdx, mandateId, null, null, null,  null, null, null, xPagopaCxTaxid, null, null, null);
+        return this.appIoPnPaymentsApi.getReceivedNotificationAttachment(iun, attachmentName, xPagopaCxTaxid, attachmentIdx, mandateId, null, null, "PublicKey", null, null, "AuthJwt", xPagopaCxTaxid, null, null, null);
     }
 
     public ResponseCheckQrMandateDto checkAarQrCodeIO(String xPagopaCxTaxid, String xPagopaLollipopUserId, RequestCheckQrMandateDto requestCheckQrMandateDto) throws RestClientException {
-        return appIoPnNotificationApi.checkAarQrCodeIO(xPagopaCxTaxid, requestCheckQrMandateDto, null, null, null, null, null, null, xPagopaLollipopUserId, null, null, null);
+        return appIoPnNotificationApi.checkAarQrCodeIO(xPagopaCxTaxid, requestCheckQrMandateDto, null, null, "PublicKey", null, null, "AuthJwt", xPagopaLollipopUserId, null, null, null);
     }
 
     public ResponseCheckQrMandateDto checkAarQrCodeIO(String xPagopaCxTaxid, RequestCheckQrMandateDto requestCheckQrMandateDto) throws RestClientException {
-        return appIoPnNotificationApi.checkAarQrCodeIO(xPagopaCxTaxid, requestCheckQrMandateDto, null, null, null, null, null, null, null, null, null, null);
+        return appIoPnNotificationApi.checkAarQrCodeIO(xPagopaCxTaxid, requestCheckQrMandateDto, null, null, "PublicKey", null, null, "AuthJwt", null, null, null, null);
     }
 
     public NotificationAttachmentDownloadMetadataResponse getReceivedNotificationAttachmentByUrl(String url, String xPagopaCxTaxid) throws RestClientException {
@@ -95,12 +95,13 @@ public class PnAppIOB2bExternalClientImpl implements IPnAppIOB2bClient {
         headerParams.add("x-pagopa-cx-taxid", appIoPnPaymentsApi.getApiClient().parameterToString(xPagopaCxTaxid));
 
         final List<MediaType> localVarAccept = appIoPnPaymentsApi.getApiClient().selectHeaderAccept(localVarAccepts);
-        final String[] contentTypes = {  };
+        final String[] contentTypes = {};
         final MediaType localVarContentType = appIoPnPaymentsApi.getApiClient().selectHeaderContentType(contentTypes);
 
-        String[] authNames = new String[] { "ApiKeyAuth" };
+        String[] authNames = new String[]{"ApiKeyAuth"};
 
-        ParameterizedTypeReference<NotificationAttachmentDownloadMetadataResponse> returnType = new ParameterizedTypeReference<>() {};
+        ParameterizedTypeReference<NotificationAttachmentDownloadMetadataResponse> returnType = new ParameterizedTypeReference<>() {
+        };
         return appIoPnPaymentsApi.getApiClient().invokeAPI(url, HttpMethod.GET, uriVariables, queryParams, postBody, headerParams, cookieParams, formParams, localVarAccept, localVarContentType, authNames, returnType).getBody();
-     }
+    }
 }

--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/utilityVersions/B2bUtils.java
@@ -548,4 +548,10 @@ public abstract class B2bUtils {
             default -> throw new IllegalArgumentException("Category non riconosciuta: " + timelineEventCategory);
         };
     }
+
+    public static String getEnvironment(ApplicationContext context) {
+        String env = context.getEnvironment().getActiveProfiles()[0];
+        log.info("Environment in use is: {}", env);
+        return env;
+    }
 }

--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/DelegheTemporaneeSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/DelegheTemporaneeSteps.java
@@ -23,6 +23,7 @@ import it.pagopa.pn.client.b2b.pa.service.IPnMandateAppIoClient;
 import it.pagopa.pn.client.b2b.pa.service.impl.PnMandateAppIoClientImpl;
 import it.pagopa.pn.client.web.generated.openapi.clients.externalMandate.model.AcceptRequestDto;
 import it.pagopa.pn.cucumber.steps.SharedSteps;
+import it.pagopa.pn.cucumber.steps.pa.utilityVersions.B2bUtils;
 import it.pagopa.pn.cucumber.steps.utilitySteps.CieGeneratorTool;
 import it.pagopa.pn.cucumber.steps.utilitySteps.Costanti;
 import it.pagopa.pn.cucumber.steps.utilitySteps.Destinatario;
@@ -141,8 +142,8 @@ public class DelegheTemporaneeSteps {
         }
         try {
             mandateCreationResponse = mandateAppIoClient.createIOMandate(
-                    taxId, null, null, null, null,
-                    null, null, lollipopUserId, null, null,
+                    taxId, null, null, "PublicKey", null,
+                    null, "AuthJwt", lollipopUserId, null, null,
                     mandateCreationRequest);
             checkMandateCreation();
         } catch (HttpStatusCodeException e) {
@@ -151,7 +152,7 @@ public class DelegheTemporaneeSteps {
     }
 
     private void setQrCode(String inputParamsType) {
-        String environment = sharedSteps.getContext().getEnvironment().getActiveProfiles()[0];
+        String environment = B2bUtils.getEnvironment(sharedSteps.getContext());
         String environmentPath;
         switch (environment) {
             case "dev" -> environmentPath = "http://cittadini.dev.notifichedigitali.it/io";
@@ -222,10 +223,10 @@ public class DelegheTemporaneeSteps {
                     mandateId,
                     null,
                     null,
+                    "PublicKey",
                     null,
                     null,
-                    null,
-                    null,
+                    "AuthJwt",
                     lollipopUserId,
                     null,
                     null,

--- a/src/test/java/it/pagopa/pn/cucumber/steps/serviceDesk/ApiServiceDeskSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/serviceDesk/ApiServiceDeskSteps.java
@@ -140,10 +140,10 @@ public class ApiServiceDeskSteps {
         }
     }
 
-     @And("si verifica che lo stato della notifica recuperata sia: {string}")
-     public void verifyNotificationStatus(String expectedStatus) {
+    @And("si verifica che lo stato della notifica recuperata sia: {string}")
+    public void verifyNotificationStatus(String expectedStatus) {
         Assertions.assertEquals(timelineResponse.getIunStatus().getValue(), expectedStatus);
-     }
+    }
 
     @Given("viene creata una nuova richiesta per invocare il servizio UNREACHABLE per il {string}")
     public void createVerifyUnreachableRequest(String cf) {
@@ -1136,7 +1136,7 @@ public class ApiServiceDeskSteps {
         log.info("ticketOperationId:" + ticketOperationId);
         createActOperationRequest.setTicketOperationId(ticketOperationId);
 
-        createActOperationRequest.setAddress(new ActDigitalAddress().address("test@test.it").type("COURTESY"));
+        createActOperationRequest.setAddress(new ActDigitalAddress().address("test@test.it").type(ActDigitalAddress.TypeEnum.valueOf("COURTESY")));
 
         String ticketDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
         createActOperationRequest.setTicketDate(ticketDate);
@@ -1165,7 +1165,7 @@ public class ApiServiceDeskSteps {
     }
 
     private void createPreUploadVideoRequestDocumentSteps(String name) throws Exception {
-        notificationDocument = newDocument("classpath:/"+name);
+        notificationDocument = newDocument("classpath:/" + name);
         String resourceName = notificationDocument.getRef().getKey();
         log.info("Resource name:" + resourceName);
         String sha256 = B2bUtils.computeSha256(ctx, resourceName);
@@ -1468,7 +1468,9 @@ public class ApiServiceDeskSteps {
 
     public String setPaID(String paId) {
         String paIDSearch;
-        if (paId == null) return sharedSteps.getB2bClient().getSentNotificationV27(sharedSteps.getNotificationIun()).getSenderPaId();;
+        if (paId == null)
+            return sharedSteps.getB2bClient().getSentNotificationV27(sharedSteps.getNotificationIun()).getSenderPaId();
+        ;
         return switch (paId.toUpperCase()) {
             case "VUOTO" -> "";
             case "NO_SET" -> {
@@ -1635,7 +1637,7 @@ public class ApiServiceDeskSteps {
 
         if (addressType != null && addressValue != null) {
             ActDigitalAddress address = new ActDigitalAddress();
-            address.setType(addressType);
+            address.setType(ActDigitalAddress.TypeEnum.valueOf(addressType));
             address.setAddress(addressValue);
             request.setAddress(address);
         } else {
@@ -1660,7 +1662,7 @@ public class ApiServiceDeskSteps {
                 this.httpResponse = ipServiceDeskClient.createActOperationWithHttpInfo(createActOperationRequest);
                 operationsResponse = maybeBody(httpResponse.body(), OperationsResponse.class).orElse(null);
 
-                if(operationsResponse != null ){
+                if (operationsResponse != null) {
                     Assertions.assertNotNull(operationsResponse.getOperationId(), "OperationId nullo nella response di CREATE_ACT_OPERATION");
                     operationId = operationsResponse.getOperationId();
                     log.info("Operation id:" + operationId);
@@ -1706,7 +1708,7 @@ public class ApiServiceDeskSteps {
 
     public void sendNotification() {
         String iun = sharedSteps.getNotificationIun();
-        if(iun != null) return;
+        if (iun != null) return;
 
         // viene generata una nuova notifica
         Map<String, String> data = new HashMap<>();
@@ -1735,7 +1737,7 @@ public class ApiServiceDeskSteps {
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             invokeApi("GET_ACT_OPERATION_STATUS");
             System.out.println("Stato attuale: " + statusOperationResponse.toUpperCase());
-            if(status.equalsIgnoreCase(statusOperationResponse.toUpperCase())) return;
+            if (status.equalsIgnoreCase(statusOperationResponse.toUpperCase())) return;
             Thread.sleep(sleepMillis);
         }
 

--- a/src/test/resources/it/pagopa/pn/cucumber/DelegheTemporanee.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/DelegheTemporanee.feature
@@ -26,8 +26,8 @@ Feature: Deleghe Temporanee 15755
     And destinatario Mario Cucumber
     And la notifica viene inviata tramite api b2b dal "Comune_Multi" e si attende che lo stato diventi "ACCEPTED"
     When Mario Gherkin viene temporaneamente delegato da Mario Cucumber passando "DATI VALIDI"
-    And la delega temporanea di Mario Cucumber viene accettata da Mario Gherkin passando "DATI VALIDI"
     And la delega temporanea è stata correttamente creata
+    And la delega temporanea di Mario Cucumber viene accettata da Mario Gherkin passando "DATI VALIDI"
     And l'operazione non ha prodotto alcun errore
     Then la notifica può essere correttamente letta tramite appIo dal delegato Mario Gherkin
     Then la notifica può essere correttamente letta da "Mario Gherkin" con delega


### PR DESCRIPTION
aggiornamento PnAppIOB2bExternalClientImpl e suite di DelegheTemporanee con l'aggiunta degli header obbligatori x-pagopa-lollipop-auth-jwt (obbligatorio, senza le chiamate vanno in 401) e x-pagopa-lollipop-public-key (non obbligatorio, ma se non presente viene effettuato più avanti un controllo che impedisce il buon esito della request).
Tali valori sono stati impostati con valori non effettivi, in quanto le utenze utilizzate sono censite in whitelist e non effettuano la validazione di tali header (si limitano a verificarne la presenza).