### PR TITLE
Ampliamento NRT

### DIFF
--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/NrtComplementareTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/NrtComplementareTest.java
@@ -12,7 +12,13 @@ import static io.cucumber.junit.platform.engine.Constants.*;
     @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "json:target/cucumber-report.json," +
         "html:target/cucumber-report.html"),
     @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "it.pagopa.pn.interop.cucumber.steps"),
-    @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "same_thread"),
+
+    // abilita parallelismo JUnit
+    @ConfigurationParameter(key = "junit.jupiter.execution.parallel.enabled", value = "true"),
+    @ConfigurationParameter(key = "junit.jupiter.execution.parallel.mode.default", value = "concurrent"),
+
+    // abilita parallelismo Cucumber
+    @ConfigurationParameter(key = EXECUTION_MODE_FEATURE_PROPERTY_NAME, value = "concurrent")
 })
 @ExcludeTags({"wait_for_fix"})
 

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/NrtTest.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/NrtTest.java
@@ -34,11 +34,13 @@ import static io.cucumber.junit.platform.engine.Constants.*;
         "agreement", "attribute", "descriptor", "document", "eservice", "purpose", "daily_calls_update_request",
         "purpose_latest_risk_analysis", "purpose_risk_analysis", "incaricato", "capofila", "selfcare",
         "app-edit-ff-on", "llgg", "e-service-template", "e-service-template-receive-bff", "purposeTemplate",
+        "client_admin", "client", "catalog", "producer", "DPoPSuite", "tenant", "voucher",
 
         // M2M
         "m2m-agreements", "m2m-purposes", "m2m-attributes", "m2m-eservices", "m2m-agreements-parte2-luglio",
         "m2m-parte2-agosto-rilascio1", "m2m-parte2-agosto-rilascio2", "m2m-parte2-settembre",
-        "m2m-parte2-ottobre", "m2mEservices", "e-service-template-receive-m2m", "m2m-client"
+        "m2m-parte2-ottobre", "m2mEservices", "e-service-template-receive-m2m", "m2m-client", "m2m-purpose-client",
+        "m2m-incaricato", "m2m-events", "e-service-template-m2m-version-get"
 
 })
 public class NrtTest {


### PR DESCRIPTION
Aggiunti test che prima erano inclusi solo in NrtComplementareTest.java . Alcuni tag sono stati esclusi, essendo parte di tag già presenti in NrtTest.java (per esempio e-service-template-instances-suffix, incluso in e-service-template)