### PR TITLE
refactor(EventPredicate)[QA-10953]: mutata in interfaccia funzionale

### DIFF
--- a/interop-qa-tests/src/main/java/it/pagopa/interop/event/filter/EventFilter.java
+++ b/interop-qa-tests/src/main/java/it/pagopa/interop/event/filter/EventFilter.java
@@ -17,12 +17,10 @@ public final class EventFilter {
     }
 
     public EventPredicate build(){
-        Predicate<M2MEvent> predicate =
-                predicates.stream()
-                    .reduce(Predicate::and)
-                    .orElse(event -> true);
-
-        return new EventPredicate(predicate);
+        return predicates.stream()
+            .reduce(Predicate::and)
+            .map(EventPredicate::from)
+            .orElse(event -> true);
     }
 
     public EventFilter like(M2MEvent filter) {

--- a/interop-qa-tests/src/main/java/it/pagopa/interop/event/filter/EventPredicate.java
+++ b/interop-qa-tests/src/main/java/it/pagopa/interop/event/filter/EventPredicate.java
@@ -1,23 +1,17 @@
 package it.pagopa.interop.event.filter;
 
 import it.pagopa.interop.event.domain.dto.M2MEvent;
-import lombok.Value;
 
 import java.util.List;
 import java.util.function.Predicate;
 
-@Value
-public class EventPredicate implements Predicate<M2MEvent> {
-    Predicate<M2MEvent> predicate;
-
-    @Override
-    public boolean test(M2MEvent m2MEvent) {
-        return predicate.test(m2MEvent);
+@FunctionalInterface
+public interface EventPredicate extends Predicate<M2MEvent> {
+    static EventPredicate from(Predicate<M2MEvent> predicate) {
+        return predicate::test;
     }
 
-    public static EventPredicate andAll(List<EventPredicate> predicates) {
-        return new EventPredicate(event ->
-                predicates.stream().allMatch(p -> p.test(event))
-        );
+    static EventPredicate andAll(List<EventPredicate> predicates) {
+        return event -> predicates.stream().allMatch(p -> p.test(event));
     }
 }

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/m2m/event/M2MEventsSteps.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/m2m/event/M2MEventsSteps.java
@@ -96,7 +96,7 @@ public class M2MEventsSteps {
     private static EventPredicate getPredicate(InteropEvent event, List<EventPredicate> predicates) {
         List<EventPredicate> safePredicates = new ArrayList<>(predicates != null ? predicates : Collections.emptyList());
 
-        EventPredicate eventTypePredicate = new EventPredicate(e -> e.getEventType().equals(event.name()));
+        EventPredicate eventTypePredicate = e -> e.getEventType().equals(event.name());
         safePredicates.add(eventTypePredicate);
 
         return EventPredicate.andAll(safePredicates);

--- a/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/m2m/event/config/EventRequestConfig.java
+++ b/interop-qa-tests/src/test/java/it/pagopa/pn/interop/cucumber/steps/m2m/event/config/EventRequestConfig.java
@@ -43,7 +43,7 @@ public class EventRequestConfig {
 
         String resolvedValue = tokenResolver.resolve(rawValue);
 
-        return new EventPredicate(event -> matchesField(event, propertyName, resolvedValue));
+        return event -> matchesField(event, propertyName, resolvedValue);
     }
 
     private boolean matchesField(M2MEvent event, String propertyName, String expectedRawValue) {

--- a/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/m2mgateway/events.feature
+++ b/interop-qa-tests/src/test/resources/it/pagopa/pn/cucumber/m2mgateway/events.feature
@@ -281,7 +281,7 @@ Feature: Eventi M2M
     And "PA2" visualizza l'evento EServiceDescriptorPublished precedente
 
   @m2m-events-agreement
-  Scenario: [M2M_E-SERVICE_EVENTS_14] Verifica, creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per erogatore, fruitore e client generico
+  Scenario: [M2M_AGREEMENT_EVENTS_01] Verifica, creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per erogatore, fruitore e client generico
   Un erogatore crea un e-service delegabile, un fruitore fa richiesta di fruizione all'erogatore. Gli eventi
   AGREEMENT_ADDED e AGREEMENT_SUBMITTED per la richiesta di fruizione sono visibili al fruitore, l'erogatore vede solo
   AGREEMENT_SUBMITTED. Un generico client non vede alcun evento.
@@ -304,7 +304,7 @@ Feature: Eventi M2M
     And "PA3" non visualizza l'evento AgreementSubmitted precedente
 
   @m2m-events-agreement
-  Scenario: [M2M_E-SERVICE_EVENTS_15] Verifica, in presenza di una delega di fruizione in stato di approvazione e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato in erogazione, erogatore e client generico
+  Scenario: [M2M_AGREEMENT_EVENTS_02] Verifica, in presenza di una delega di fruizione in stato di approvazione e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato in erogazione, erogatore e client generico
   Un erogatore crea un e-service delegabile, un delegante delega in erogazione un delegato, il delegato fa richiesta di
   fruizione all'erogatore. Gli eventi AGREEMENT_ADDED e AGREEMENT_SUBMITTED per la richiesta di fruizione sono visibili
   al creatore della richiesta , l'erogatore e il delegato all'erogazione vedono solo AGREEMENT_SUBMITTED.
@@ -327,7 +327,7 @@ Feature: Eventi M2M
     And "PA2" non visualizza l'evento AgreementSubmitted precedente
 
   @m2m-events-agreement
-  Scenario: [M2M_E-SERVICE_EVENTS_16] Verifica, in presenza di una delega di fruizione rifiutata e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato in erogazione, erogatore e client generico
+  Scenario: [M2M_AGREEMENT_EVENTS_03] Verifica, in presenza di una delega di fruizione rifiutata e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato in erogazione, erogatore e client generico
   Un erogatore crea un e-service, un delegante delega in erogazione un delegato, il delegato rifiuta la delega
   di erogazione, il delegato fa richiesta di fruizione all'erogatore. Gli eventi AGREEMENT_ADDED e AGREEMENT_SUBMITTED
   per la richiesta di fruizione sono visibili al richiedente, l'erogatore vede solo AGREEMENT_SUBMITTED.
@@ -354,7 +354,7 @@ Feature: Eventi M2M
     And "PA4" non visualizza l'evento AgreementSubmitted precedente
 
   @m2m-events-agreement
-  Scenario: [M2M_E-SERVICE_EVENTS_17] Verifica, in presenza di una delega in erogazione accettata e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato, erogatore e client generico
+  Scenario: [M2M_AGREEMENT_EVENTS_04] Verifica, in presenza di una delega in erogazione accettata e creata una richiesta di fruizione, che l'evento di agreement di un e-service abbia la corretta visibilità per delegante, delegato, erogatore e client generico
   Un erogatore crea un e-service, un delegante delega in erogazione un delegato, il delegato accetta la delega
   in erogazione, il delegato fa richiesta di fruizione. Gli eventi AGREEMENT_ADDEDe AGREEMENT_SUBMITTED per la richiesta di fruizione sono visibili al richiedente.
   Il delegante e il delegato vedono AGREEMENT_SUBMITTED. Un generico client non vede alcun evento.


### PR DESCRIPTION
Non si rilevano ragioni per cui EventPredicate debba essere legato a Predicate sia da ereditarietà che da composizione. La si trasforma in un'interfaccia funzionale adeguando le dependencies di conseguenza.