### PR TITLE
fix(AvanzamentoNotificheWebhookB2bSteps): [PN-19952]

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/pa/AvanzamentoNotificheWebhookB2bSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/pa/AvanzamentoNotificheWebhookB2bSteps.java
@@ -231,10 +231,14 @@ public class AvanzamentoNotificheWebhookB2bSteps {
 
     @When("si crea(no) i(l) nuov(o)(i) stream per il {string} con versione {string} e filtro status {string}")
     public void createStreamWithFilteredStatus(String pa, String version, String filter) {
+        String[] filterValues = new String[]{filter};
+        if (filter.contains(",")) {
+            filterValues = filter.split(",");
+        }
         setPaWebhook(pa);
         updateApiKeyForStream();
         StreamVersion streamVersion = getStreamVersion(version);
-        createStream(pa, streamVersion, null, false, List.of(filter), false, null);
+        createStream(pa, streamVersion, null, false, Arrays.asList(filterValues), false, null);
     }
 
     @When("si crea(no) i(l) nuov(o)(i) stream con versione {string} per il {string} con un gruppo disponibile {string}")

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v27/WebhookV27Creation.feature
@@ -36,6 +36,47 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
     And l'apiKey viene cancellata
 
+
+  #https://pagopa.atlassian.net/browse/PN-19952
+  # Test che verifica che se viene creato uno stream con waitForAccepted a true e filtro status che non contiene DEFAULT o REQUEST_ACCEPTED allora lo stream non viene creato
+  # e viene ritornato un errore 403
+  @webhookV27 @precondition @cleanWebhook @webhook2
+  Scenario: [B2B-STREAM_PN_19952_1_KO] Creazione di uno stream con waitForAccepted a true e filtro status che non contiene DEFAULT o REQUEST_ACCEPTED.
+  Si verifica che la creazione dello stream ritorni un errore 403.
+    Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
+    And si predispongono 5 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V27"
+    And agli stream versione "V27" si setta il campo waitForAccepted introdotto con la versione 27 a "true"
+    And Viene creata una nuova apiKey per il comune "Comune_Multi" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    When si crea il nuovo stream per il "Comune_Multi" con versione "V27" e filtro status "DELIVERING"
+    Then l'operazione ha prodotto un errore con status code "403"
+    And viene modificato lo stato dell'apiKey in "BLOCK"
+    And l'apiKey viene cancellata
+
+
+  #https://pagopa.atlassian.net/browse/PN-19952
+  # Test che verifica che se viene creato uno stream con waitForAccepted a true e filtro status che contiene DEFAULT o REQUEST_ACCEPTED allora lo stream non viene creato con successo
+  @webhookV27 @precondition @cleanWebhook @webhook2
+  Scenario Outline: [B2B-STREAM_PN_19952_2_OK] Creazione di uno stream con waitForAccepted a true e filtro status che contiene DEFAULT o REQUEST_ACCEPTED. Si verifica che lo stream venga creato con successo.
+    Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V27"
+    And si predispongono 5 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V27"
+    And agli stream versione "V27" si setta il campo waitForAccepted introdotto con la versione 27 a "true"
+    And Viene creata una nuova apiKey per il comune "Comune_Multi" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    When si crea il nuovo stream per il "Comune_Multi" con versione "V27" e filtro status "<statusFilter>"
+    Then lo stream è stato creato e viene correttamente recuperato dal sistema tramite stream id con versione "V27"
+    And si cancella lo stream creato per il "Comune_Multi" con versione "V27"
+    And viene verificata la corretta cancellazione con versione "V27"
+    And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
+    And l'apiKey viene cancellata
+    Examples:
+      | statusFilter                        |
+      | DELIVERING,DEFAULT                  |
+      | DELIVERING,REQUEST_ACCEPTED         |
+      | DELIVERING,DEFAULT,REQUEST_ACCEPTED |
+
   @webhookV27 @precondition @cleanWebhook @webhook2
   #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.

--- a/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v29/WebhookV29Creation.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/workflowNotifica/webhook/v29/WebhookV29Creation.feature
@@ -36,6 +36,46 @@ Feature: verifica creazione stream
     And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
     And l'apiKey viene cancellata
 
+  #https://pagopa.atlassian.net/browse/PN-19952
+  # Test che verifica che se viene creato uno stream con waitForAccepted a true e filtro status che non contiene DEFAULT o REQUEST_ACCEPTED allora lo stream non viene creato
+  # e viene ritornato un errore 403
+  @webhookV29 @precondition @cleanWebhook @webhook2
+  Scenario: [B2B-STREAM_PN_19952_1_KO] Creazione di uno stream con waitForAccepted a true e filtro status che non contiene DEFAULT o REQUEST_ACCEPTED.
+  Si verifica che la creazione dello stream ritorni un errore 403.
+    Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V29"
+    And si predispongono 5 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V29"
+    And agli stream versione "V29" si setta il campo waitForAccepted introdotto con la versione 29 a "true"
+    And Viene creata una nuova apiKey per il comune "Comune_Multi" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    When si crea il nuovo stream per il "Comune_Multi" con versione "V29" e filtro status "DELIVERING"
+    Then l'operazione ha prodotto un errore con status code "403"
+    And viene modificato lo stato dell'apiKey in "BLOCK"
+    And l'apiKey viene cancellata
+
+
+  #https://pagopa.atlassian.net/browse/PN-19952
+  # Test che verifica che se viene creato uno stream con waitForAccepted a true e filtro status che contiene DEFAULT o REQUEST_ACCEPTED allora lo stream non viene creato con successo
+  @webhookV29 @precondition @cleanWebhook @webhook2
+  Scenario Outline: [B2B-STREAM_PN_19952_2_OK] Creazione di uno stream con waitForAccepted a true e filtro status che contiene DEFAULT o REQUEST_ACCEPTED. Si verifica che lo stream venga creato con successo.
+    Given vengono cancellati tutti gli stream presenti del "Comune_Multi" con versione "V29"
+    And si predispongono 5 nuovi stream denominati "stream-test" con eventType "TIMELINE" con versione "V29"
+    And agli stream versione "V29" si setta il campo waitForAccepted introdotto con la versione 29 a "true"
+    And Viene creata una nuova apiKey per il comune "Comune_Multi" senza gruppo
+    And viene impostata l'apikey appena generata
+    And viene aggiornata la apiKey utilizzata per gli stream
+    When si crea il nuovo stream per il "Comune_Multi" con versione "V29" e filtro status "<statusFilter>"
+    Then lo stream è stato creato e viene correttamente recuperato dal sistema tramite stream id con versione "V29"
+    And si cancella lo stream creato per il "Comune_Multi" con versione "V29"
+    And viene verificata la corretta cancellazione con versione "V29"
+    And viene modificato lo stato dell'apiKey in "BLOCK" per il "Comune_Multi"
+    And l'apiKey viene cancellata
+    Examples:
+      | statusFilter                        |
+      | DELIVERING,DEFAULT                  |
+      | DELIVERING,REQUEST_ACCEPTED         |
+      | DELIVERING,DEFAULT,REQUEST_ACCEPTED |
+
   @webhookV29 @precondition @cleanWebhook @webhook2
   #LIMITE SPECIFICO PER PA: n/a; LIMITE DEFAULT (pnConfigurations.MaxStreams  = 10)
   Scenario: [B2B-STREAM_ES1.1_2] Creazione per una PA di 11 nuovi stream notifica con eventType TIMELINE e senza gruppo.


### PR DESCRIPTION
Aggiornato il metodo di creazione dello stream per gestire correttamente i filtri di stato e aggiunti nuovi scenari di test a copertura del bug https://pagopa.atlassian.net/browse/PN-19952