### PR TITLE
hotfix(Refactor DynamoDbService)[QA-15594] 

### DIFF
--- a/src/main/java/it/pagopa/pn/client/b2b/pa/service/DynamoDbService.java
+++ b/src/main/java/it/pagopa/pn/client/b2b/pa/service/DynamoDbService.java
@@ -44,7 +44,7 @@ public class DynamoDbService {
     }
 
     private static QueryRequest queryWithoutFilters(DynamoTableName tableName, String column, Map<String, AttributeValue> attributeValues) {
-        return queryWithFilters(tableName, List.of(column), attributeValues);
+        return queryWithoutFilters(tableName, List.of(column), attributeValues);
     }
 
     /**


### PR DESCRIPTION
correzione typo (il metod ooverloadato queryWithoutFilters(DynamoTableName tableName, String column, Map<String, AttributeValue> attributeValues)

richiamava erroneamente queryWithFilters anzichè queryWithoutFilters