### PR TITLE
hotfix(Cruscotto Assistenza fix suite): [QA-16449]

### DIFF
--- a/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/recipient/RicezioneNotificheWebSteps.java
@@ -1163,6 +1163,31 @@ public class RicezioneNotificheWebSteps {
                 });
     }
 
+    @And("viene controllato che sia presente la pec verificate {string} inserita per il comune {string}")
+    public void waitedAndViewedPecDiPiattaformaDi(String pec, String pa) {
+        String senderId = getSenderIdPa(pa);
+
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .pollInterval(5, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    List<LegalCourtesyAddressWrapper> legalAddresses =
+                            this.iPnWebUserAttributesClient.getLegalAddressByRecipient();
+
+                    Assertions.assertNotNull(legalAddresses, "Lista indirizzi nulla");
+                    Assertions.assertTrue(
+                            legalAddresses.stream()
+                                    .anyMatch(address ->
+                                            LegalChannelType.PEC.getValue().equals(address.getChannelType().getValue())
+                                                    && senderId.equals(address.getSenderId())
+                                                    && Boolean.TRUE.equals(address.getPecValid())
+                                                    && address.getValue().equals(pec)),
+                            "PEC NOT FOUND"
+                    );
+                });
+    }
+
     @And("viene rimossa se presente la pec per il comune {string}")
     public void vieneRimossaSePresenteLaPecDiPiattaformaDi(String pa) {
         String senderId = getSenderIdPa(pa);

--- a/src/test/java/it/pagopa/pn/cucumber/steps/serviceDesk/ApiServiceDeskSteps.java
+++ b/src/test/java/it/pagopa/pn/cucumber/steps/serviceDesk/ApiServiceDeskSteps.java
@@ -1522,7 +1522,8 @@ public class ApiServiceDeskSteps {
     private String createIUN(String iun) {
         return switch (iun.toUpperCase()) {
             case "VUOTO" -> "";
-            case "INESISTENTE" -> IUN_ERRATO;
+            case "INESISTENTE" -> INEXISTENT_IUN;
+            case "NON VALIDO" -> INVALID_IUN;
             case "ASSOCIATO A PAGAMENTO PAGOPA" -> iunWithPagoPAPayment;
             case "ASSOCIATO A PAGAMENTO F24" -> iunWithF24Payment;
             case "NOTIFICA SENZA PAGAMENTI" -> iunWithoutPayment;

--- a/src/test/resources/it/pagopa/pn/cucumber/serviceDesk/ApiServiceCruscottoAssistenza.feature
+++ b/src/test/resources/it/pagopa/pn/cucumber/serviceDesk/ApiServiceCruscottoAssistenza.feature
@@ -688,7 +688,7 @@ Feature: Api Service Cruscotto Assistenza
     And viene inserito un recapito legale "example3@pecSuccess.it"
     And viene controllato che siano presenti pec verificate inserite per il comune "default"
     And viene inserito un recapito legale "example2@pecSuccess.it"
-    And viene controllato che siano presenti pec verificate inserite per il comune "default"
+    And viene controllato che sia presente la pec verificate "example2@pecSuccess.it" inserita per il comune "default"
     When come operatore devo accedere ai dati del profilo di un utente (PF e PG) di Piattaforma Notifiche con taxId "Galileo Galilei" e recipientType  "PF"
     Then controllo che i timestamp di creazione e modifica del recapito "legale" "PEC" siano "diverse" tra di loro
 
@@ -715,7 +715,7 @@ Feature: Api Service Cruscotto Assistenza
     And viene verificato che Sercq sia "abilitato" per il comune "default"
     And viene disabilitato il servizio SERCQ SEND per il comune "default"
     When come operatore devo accedere ai dati del profilo di un utente (PF e PG) di Piattaforma Notifiche con taxId "Galileo Galilei" e recipientType  "PF"
-    Then controllo che i timestamp di creazione e modifica del recapito "legale" "SERCQ" siano "vuoti"
+    Then controllo che i timestamp di creazione e modifica del recapito "legale" "SERCQ" siano "vuoti" tra di loro
 
   @evolutiveCruscottoAssistenza
   Scenario Outline: [EVOLUTIVE_CRUSCOTTO_ASSISTENZA_7] Recupero del dettaglio della notifica con i pagamenti associati con l’utilizzo di uno IUN vuoto - IUN inesistente - IUN non associato allo User
@@ -723,6 +723,7 @@ Feature: Api Service Cruscotto Assistenza
     Then il servizio risponde con errore "<ERROR>"
     Examples:
       | USER           | IUN                      | UID      | ERROR |
+      | Mario Gherkin  | NON VALIDO               | corretto | 400   |
       | Mario Gherkin  | VUOTO                    | corretto | 400   |
       | Mario Gherkin  | INESISTENTE              | corretto | 404   |
       |                | NOTIFICA SENZA PAGAMENTI | corretto | 400   |


### PR DESCRIPTION
 Correction of test cases; added a step to verify that the legal address inserted is the one specified in the previous request (forces a longer polling)